### PR TITLE
chore(274): add self-contained coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
             - run: yarn test:coverage
             - name: Report coverage
               if: matrix.node-version == 24
-              uses: davelosert/vitest-coverage-report-action@v2
+              uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2
             - name: Extract coverage percentage
               id: coverage
               if: matrix.node-version == 24 && github.event_name == 'push'
               run: echo "percentage=$(jq '.total.lines.pct' coverage/coverage-summary.json)" >> $GITHUB_OUTPUT
             - name: Update coverage badge
               if: matrix.node-version == 24 && github.event_name == 'push'
-              uses: schneegans/dynamic-badges-action@v1.8.0
+              uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
               with:
                   auth: ${{ secrets.GIST_SECRET }}
                   gistID: ${{ vars.COVERAGE_GIST_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ env:
 jobs:
     ci:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
         strategy:
             fail-fast: false
             matrix:
@@ -29,4 +32,23 @@ jobs:
             - run: yarn install --frozen-lockfile
             - run: yarn format:check
             - run: yarn lint
-            - run: yarn test
+            - run: yarn test:coverage
+            - name: Report coverage
+              if: matrix.node-version == 24
+              uses: davelosert/vitest-coverage-report-action@v2
+            - name: Extract coverage percentage
+              id: coverage
+              if: matrix.node-version == 24 && github.event_name == 'push'
+              run: echo "percentage=$(jq '.total.lines.pct' coverage/coverage-summary.json)" >> $GITHUB_OUTPUT
+            - name: Update coverage badge
+              if: matrix.node-version == 24 && github.event_name == 'push'
+              uses: schneegans/dynamic-badges-action@v1.8.0
+              with:
+                  auth: ${{ secrets.GIST_SECRET }}
+                  gistID: ${{ vars.COVERAGE_GIST_ID }}
+                  filename: coverage.json
+                  label: coverage
+                  message: ${{ steps.coverage.outputs.percentage }}%
+                  valColorRange: ${{ steps.coverage.outputs.percentage }}
+                  maxColorRange: 100
+                  minColorRange: 0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # data-sanitization
 
 [![Node CI](https://github.com/ioncache/data-sanitization/actions/workflows/ci.yml/badge.svg)](https://github.com/ioncache/data-sanitization/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ioncache/e2afdd1c4942b8c99362ceb3853a331e/raw/coverage.json)](https://github.com/ioncache/data-sanitization/actions/workflows/ci.yml)
 
 Pattern-based sanitization for sensitive data in objects and strings. Masks or removes fields matching configurable patterns, making data safe for logging or external exposure.
 

--- a/docs/plans/001-coverage-tracking.md
+++ b/docs/plans/001-coverage-tracking.md
@@ -1,4 +1,4 @@
-# Coverage Tracking Workflow
+# Coverage Tracking
 
 ## Approach
 

--- a/docs/plans/001-coverage-tracking.md
+++ b/docs/plans/001-coverage-tracking.md
@@ -1,0 +1,78 @@
+# Coverage Tracking Workflow
+
+## Approach
+
+Replace Codecov with a self-contained GitHub-native coverage setup. Vitest
+generates coverage reports that the CI job uses in two ways: posting a per-file
+coverage table as a PR comment, and writing the coverage percentage to a GitHub
+Gist from which a Shields.io dynamic badge is served in the README. No external
+accounts are required beyond GitHub.
+
+## Pre-implementation
+
+- Create a public GitHub Gist with a file named `coverage.json`
+- Create a classic PAT with `gist` scope at https://github.com/settings/tokens
+- Add the PAT as repository secret `GIST_SECRET`
+- Add the Gist ID as repository variable `COVERAGE_GIST_ID`
+- Create GitHub issue #274
+- Create branch `chore/274/coverage_tracking`
+
+## Steps
+
+1. `docs/plans/001-coverage-tracking.md` — this plan
+
+2. `vitest.config.ts` — add `reporters: ['text', 'json-summary', 'json']`
+   inside the `coverage` block; `json-summary` is required by the PR comment
+   action, `json` provides per-file detail
+
+3. `.github/workflows/ci.yml` — add `permissions: pull-requests: write` to the
+   job; replace `yarn test` with `yarn test:coverage`; append three steps gated
+   on `matrix.node-version == 24`:
+   - `davelosert/vitest-coverage-report-action@v2` — posts per-file coverage
+     table as a PR comment; runs on both push and PR events
+   - Extract coverage percentage from `coverage/coverage-summary.json` using
+     `jq`; gated additionally on `github.event_name == 'push'`
+   - `schneegans/dynamic-badges-action@v1.8.0` — writes Shields.io endpoint
+     JSON to the Gist using `GIST_SECRET` and `COVERAGE_GIST_ID`; gated
+     additionally on `github.event_name == 'push'`
+
+4. `README.md` — add Shields.io dynamic badge after the Node CI badge; badge
+   URL reads from the Gist via `https://img.shields.io/endpoint?url=...`
+
+## Relevant Files
+
+- `docs/plans/001-coverage-tracking.md` — new, this plan
+- `vitest.config.ts` — updated, add coverage reporters
+- `.github/workflows/ci.yml` — updated, replace test command and add coverage steps
+- `README.md` — updated, add coverage badge
+
+## Verification
+
+1. Push to `main` — `yarn test:coverage` runs on both Node versions; the Node
+   24 step updates the Gist; the README badge reflects the current coverage
+2. Open a PR — the Node 24 step posts a per-file coverage comment
+3. README badge renders dynamically from the Gist without any external service
+   login
+
+## Decisions
+
+**No new CI job** — coverage post-processing is appended to the existing matrix
+job and gated on `node-version == 24`. This avoids running tests twice and
+keeps the workflow file simple.
+
+**Gist update on push to main only** — the `GIST_SECRET` PAT is not available
+to workflows triggered by fork PRs. The coverage thresholds enforced by Vitest
+already fail the CI job if coverage drops, so the badge only needs to update on
+merged code.
+
+**PR comment uses `GITHUB_TOKEN`** — always available, no extra secret needed.
+
+**`davelosert/vitest-coverage-report-action` over official Vitest tooling** —
+Vitest's built-in `github-actions` reporter (enhanced in v4.1.0) handles test
+result summaries only, not coverage. There is no official Vitest coverage
+action. The `davelosert` action is community-maintained, actively developed
+(v2.12.0 released May 2026), and is the de facto standard for this use case.
+
+**Shields.io + Gist over SVG badges committed to the repo** — the Gist
+approach keeps badge updates out of the commit history. The trade-off is a
+one-time PAT setup, which is acceptable.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/constants.ts', 'src/types.ts'],
+      reporters: ['text', 'json-summary', 'json'],
       thresholds: {
         lines: 100,
         functions: 100,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/constants.ts', 'src/types.ts'],
-      reporters: ['text', 'json-summary', 'json'],
+      reporter: ['text', 'json-summary', 'json'],
       thresholds: {
         lines: 100,
         functions: 100,


### PR DESCRIPTION
# Overview

Track coverage in the repo without having to use an external service like codecov or coveralls

## Related Tickets and/or Pull Requests

Closes #274 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a public plan describing migration to GitHub-native coverage tracking and added a dynamic coverage badge to the README.

* **Chores**
  * CI now runs coverage-aware tests on pushes and updates a dynamic coverage badge automatically; job permissions adjusted.

* **Tests**
  * Test runner configured to emit JSON-based coverage outputs for reporting and badge generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->