### PR TITLE
feat: write markdown coverage report to Gist on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,9 @@ jobs:
                   valColorRange: ${{ steps.coverage.outputs.percentage }}
                   maxColorRange: 100
                   minColorRange: 0
+            - name: Update coverage report in Gist
+              if: matrix.node-version == 24 && github.event_name == 'push'
+              env:
+                  COVERAGE_GIST_ID: ${{ vars.COVERAGE_GIST_ID }}
+                  GIST_SECRET: ${{ secrets.GIST_SECRET }}
+              run: node scripts/update-coverage-gist.mjs

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # data-sanitization
 
 [![Node CI](https://github.com/ioncache/data-sanitization/actions/workflows/ci.yml/badge.svg)](https://github.com/ioncache/data-sanitization/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ioncache/e2afdd1c4942b8c99362ceb3853a331e/raw/coverage.json)](https://github.com/ioncache/data-sanitization/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ioncache/e2afdd1c4942b8c99362ceb3853a331e/raw/coverage.json)](https://gist.github.com/ioncache/e2afdd1c4942b8c99362ceb3853a331e)
 
 Pattern-based sanitization for sensitive data in objects and strings. Masks or removes fields matching configurable patterns, making data safe for logging or external exposure.
 

--- a/scripts/update-coverage-gist.mjs
+++ b/scripts/update-coverage-gist.mjs
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * @typedef {Object} CoverageMetric
+ * @property {number} total - Total count
+ * @property {number} covered - Covered count
+ * @property {number} skipped - Skipped count
+ * @property {number} pct - Coverage percentage
+ */
+
+/**
+ * @typedef {Object} CoverageTotals
+ * @property {CoverageMetric} lines
+ * @property {CoverageMetric} statements
+ * @property {CoverageMetric} functions
+ * @property {CoverageMetric} branches
+ */
+
+/**
+ * Returns an emoji status icon based on coverage percentage.
+ *
+ * @param {number} pct - Coverage percentage (0–100)
+ * @returns {string} Emoji status icon
+ *
+ * @example
+ * statusIcon(100) // '🔵'
+ * statusIcon(95)  // '🟢'
+ * statusIcon(75)  // '🟡'
+ * statusIcon(50)  // '🔴'
+ */
+function statusIcon(pct) {
+  if (pct >= 100) return '🔵';
+  if (pct >= 90) return '🟢';
+  if (pct >= 70) return '🟡';
+  return '🔴';
+}
+
+/**
+ * Formats a single coverage category as a GFM table row.
+ *
+ * @param {string} category - Category name (e.g. 'Lines')
+ * @param {CoverageMetric} metric - Coverage metric data
+ * @returns {string} Markdown table row
+ *
+ * @example
+ * tableRow('Lines', { pct: 100, covered: 56, total: 56, skipped: 0 })
+ * // '| 🔵 | Lines | 100% | 56 / 56 |'
+ */
+function tableRow(category, metric) {
+  const { pct, covered, total } = metric;
+  return `| ${statusIcon(pct)} | ${category} | ${pct}% | ${covered} / ${total} |`;
+}
+
+/**
+ * Builds a markdown coverage report table from coverage totals.
+ *
+ * @param {CoverageTotals} totals - Coverage summary totals
+ * @returns {string} Formatted GFM markdown report
+ *
+ * @example
+ * buildMarkdown(summary.total)
+ * // '## Coverage Report\n\n| Status | Category | ...'
+ */
+function buildMarkdown(totals) {
+  const lines = [
+    '## Coverage Report',
+    '',
+    '| Status | Category | Percentage | Covered / Total |',
+    '| :---: | :--- | ---: | ---: |',
+    tableRow('Lines', totals.lines),
+    tableRow('Statements', totals.statements),
+    tableRow('Functions', totals.functions),
+    tableRow('Branches', totals.branches),
+  ];
+
+  return lines.join('\n');
+}
+
+/**
+ * Updates the `coverage-report.md` file on a GitHub Gist.
+ *
+ * @param {string} gistId - GitHub Gist ID
+ * @param {string} token - GitHub PAT with gist scope
+ * @param {string} content - Markdown content to write
+ * @returns {Promise<void>}
+ * @throws {Error} When the GitHub API request returns a non-OK status
+ */
+async function updateGist(gistId, token, content) {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({
+      files: {
+        'coverage-report.md': { content },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API error ${response.status}: ${body}`);
+  }
+}
+
+const gistId = process.env.COVERAGE_GIST_ID;
+const token = process.env.GIST_SECRET;
+
+if (!gistId || !token) {
+  console.error('COVERAGE_GIST_ID and GIST_SECRET must be set');
+  process.exit(1);
+}
+
+const summary = JSON.parse(
+  readFileSync('coverage/coverage-summary.json', 'utf8'),
+);
+const markdown = buildMarkdown(summary.total);
+
+await updateGist(gistId, token, markdown);
+console.log('Coverage report updated in Gist.');

--- a/scripts/update-coverage-gist.mjs
+++ b/scripts/update-coverage-gist.mjs
@@ -83,23 +83,40 @@ function buildMarkdown(totals) {
  * @param {string} token - GitHub PAT with gist scope
  * @param {string} content - Markdown content to write
  * @returns {Promise<void>}
- * @throws {Error} When the GitHub API request returns a non-OK status
+ * @throws {Error} When the GitHub API request times out or returns a non-OK status
  */
 async function updateGist(gistId, token, content) {
-  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
-    method: 'PATCH',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-    },
-    body: JSON.stringify({
-      files: {
-        'coverage-report.md': { content },
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+  let response;
+
+  try {
+    response = await fetch(`https://api.github.com/gists/${gistId}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
       },
-    }),
-  });
+      body: JSON.stringify({
+        files: {
+          'coverage-report.md': { content },
+        },
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error('GitHub API request timed out after 15s', {
+        cause: error,
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   if (!response.ok) {
     const body = await response.text();
@@ -118,6 +135,18 @@ if (!gistId || !token) {
 const summary = JSON.parse(
   readFileSync('coverage/coverage-summary.json', 'utf8'),
 );
+
+if (
+  !summary?.total?.lines ||
+  !summary?.total?.statements ||
+  !summary?.total?.functions ||
+  !summary?.total?.branches
+) {
+  throw new Error(
+    'Invalid coverage/coverage-summary.json: missing total coverage metrics',
+  );
+}
+
 const markdown = buildMarkdown(summary.total);
 
 await updateGist(gistId, token, markdown);


### PR DESCRIPTION
# Overview

Adds a markdown coverage report to the existing Gist so clicking the coverage badge shows a formatted per-category breakdown, not just the badge number.

## Details

- `scripts/update-coverage-gist.mjs` — new script that reads `coverage/coverage-summary.json` and writes a `coverage-report.md` file to the Gist via the GitHub API, matching the table format used by `vitest-coverage-report-action` in PR comments
- CI now runs the script on every push to `main` (Node 24 only), alongside the existing badge JSON update; both use the same `GIST_SECRET` and `COVERAGE_GIST_ID`
- Coverage badge in README now links to the Gist (`gist.github.com/...`) instead of the CI workflows page

## Related Tickets and/or Pull Requests

Supersedes coverage badge linking in #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project badges to include a new coverage shield linking to the coverage report.

* **Chores**
  * Added automation to generate and publish an up-to-date coverage report to an external hosted file.
  * CI workflow now runs the coverage-publishing step for the targeted runtime to keep the public report current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->