### PR TITLE
fix(277): fully mask form-encoded values

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -18,10 +18,6 @@ const escapePattern = (pattern: string): string =>
  * Matches field names in url form encoded data, or other types of
  * data similarly character delimited
  *
- * NOTE: this can partially fail if a non-word character is found
- *       before the end of the value is reached, but in that case
- *       it will still partially mask the value
- *
  * @example
  * // when masked: 'password=mask'
  * formEncodedMatcher('password=foo')
@@ -62,7 +58,7 @@ const formEncodedMatcher: DataSanitizationMatcher = (
       'gi',
     );
   }
-  return new RegExp(`(\\w*${escaped}\\w*[=:])(?:\\W?.*?)([\\W]|$)`, 'gi');
+  return new RegExp(`(\\w*${escaped}\\w*[=:])[^&]*(&|$)`, 'gi');
 };
 
 /**

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -49,6 +49,21 @@ describe('DataSanitizationMatchers', () => {
       expect(allMatches[0]?.[1]).toEqual('password:');
     });
 
+    it('should match form values containing non-delimiter punctuation', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('password');
+      const testData = 'password=abc-123%2Ba/b.c:z+q&username=mark';
+
+      // Act
+      const allMatches = [...testData.matchAll(matcher)];
+
+      // Assert
+      expect(allMatches.length).toBe(1);
+      expect(allMatches[0]?.[0]).toEqual('password=abc-123%2Ba/b.c:z+q&');
+      expect(allMatches[0]?.[1]).toEqual('password=');
+      expect(allMatches[0]?.[2]).toEqual('&');
+    });
+
     it('should match case-insensitively', () => {
       // Arrange
       const matcher = formEncodedMatcher('password');
@@ -108,6 +123,18 @@ describe('DataSanitizationMatchers', () => {
 
       // Assert
       expect(result).toBe('');
+    });
+
+    it('should produce a removal regex that removes punctuated values', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('password', true);
+      const testData = 'password=abc-123%2Ba/b.c:z+q&username=mark';
+
+      // Act
+      const result = testData.replace(matcher, '');
+
+      // Assert
+      expect(result).toBe('username=mark');
     });
   });
 

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -130,6 +130,20 @@ describe('DataSanitizationReplacers', () => {
         expect(result.password).toEqual(DEFAULT_PATTERN_MASK);
         expect(result.username).toEqual('bar');
       });
+
+      it('should fully mask form values containing non-delimiter punctuation', () => {
+        // Arrange
+        const testData =
+          'password=abc-123&token=a%2Bb%2Fc&secret=a.b:c+z/9&username=mark';
+
+        // Act
+        const result = stringReplacer(testData) as string;
+
+        // Assert
+        expect(result).toBe(
+          `password=${DEFAULT_PATTERN_MASK}&token=${DEFAULT_PATTERN_MASK}&secret=${DEFAULT_PATTERN_MASK}&username=mark`,
+        );
+      });
     });
 
     describe('removal', () => {
@@ -187,6 +201,20 @@ describe('DataSanitizationReplacers', () => {
 
         // Assert
         expect(result).toBe('');
+      });
+
+      it('should remove complete form values containing non-delimiter punctuation', () => {
+        // Arrange
+        const testData =
+          'password=abc-123&token=a%2Bb%2Fc&secret=a.b:c+z/9&username=mark';
+
+        // Act
+        const result = stringReplacer(testData, {
+          removeMatches: true,
+        }) as string;
+
+        // Assert
+        expect(result).toBe('username=mark');
       });
     });
 


### PR DESCRIPTION
# Overview

Fixes form-encoded sanitization so sensitive values containing punctuation or URL-encoded characters are fully masked instead of leaving suffixes visible after the first non-word character.

## Details

- Updated `formEncodedMatcher` masking behavior to consume the complete field value up to the `&` delimiter.
- Preserved delimiter handling so adjacent form fields remain intact after masking.
- Removed the outdated matcher note that documented partial masking as expected behavior.
- Added regression coverage for punctuated and URL-encoded-like form values in matcher and replacer tests.
- Verified removal mode still removes complete matched fields and leaves clean form-encoded output.

## Related Tickets and/or Pull Requests

Fixes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced form-encoded field pattern matching to correctly handle values containing special characters, punctuation, and URL-encoded sequences.

* **Tests**
  * Added test cases to verify proper matching, masking, and removal of form-encoded fields with special characters and punctuation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->