### PR TITLE
feat: add numericMask option for number-typed sensitive values

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ sanitizeData(patient, {
 
 | Option               | Type                        | Default      | Description                                         |
 | -------------------- | --------------------------- | ------------ | --------------------------------------------------- |
-| `patternMask`        | `string`                    | `**********` | String used to replace matched field values         |
+| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values  |
+| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values  |
 | `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking   |
 | `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match             |
 | `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats |
@@ -242,6 +243,17 @@ sanitizeData(data, {
 sanitizeData(data, {
   patternMask: '[REDACTED]',
 });
+```
+
+Number-typed sensitive values are masked with `numericMask` to preserve the
+field's type:
+
+```typescript
+sanitizeData({ password: 12345, username: 'mark' });
+// => { password: 9999999999, username: 'mark' }
+
+sanitizeData({ password: 12345, username: 'mark' }, { numericMask: 0 });
+// => { password: 0, username: 'mark' }
 ```
 
 For custom data formats, provide a `DataSanitizationMatcher` — a function that

--- a/docs/plans/009-numeric-mask.md
+++ b/docs/plans/009-numeric-mask.md
@@ -1,0 +1,101 @@
+# Numeric Mask for Number-Typed Sensitive Values
+
+## Approach
+
+Add a `numericMask` option (default `9999999999`) applied by `objectReplacer`
+when a sensitive key holds a `number`-typed value. Without this, masking a
+numeric value with the string `patternMask` silently changes the field's type.
+`numericMask` is overridable via options, parallel to how `patternMask` works
+for strings.
+
+This change is additive and contained to constants, types, and `objectReplacer`.
+`stringReplacer` is unaffected: in string input, everything is already a string,
+so there is no type to preserve.
+
+## Pre-implementation
+
+Create branch `feat/numeric-mask` from `main`.
+
+## Steps
+
+1. `docs/plans/009-numeric-mask.md` — add this plan.
+2. `src/constants.ts` — add `DEFAULT_NUMERIC_MASK = 9999999999` and include it
+   in the named export.
+3. `src/types.ts` — add `numericMask?: number` to
+   `DataSanitizationReplacerOptions` with a TSDoc comment parallel to the
+   existing `patternMask` entry.
+4. `test/replacers.test.ts` — before touching the implementation, add tests that
+   assert the **current** string-mask behavior for number-typed values. These
+   tests must pass before the implementation step and will go red after it:
+   - `{ password: 123 }` → `password` is `DEFAULT_PATTERN_MASK`
+   - `{ token: 42, username: 'mark' }` → `token` is `DEFAULT_PATTERN_MASK`,
+     `username` is `'mark'`
+
+   Note: the existing test `'should mask sensitive object keys with non-string
+values'` (test/replacers.test.ts:320) also asserts `password: 123` →
+   `DEFAULT_PATTERN_MASK` and will go red at the same time.
+
+   Run `yarn test` to confirm all new and existing tests pass before proceeding.
+
+5. `src/replacers.ts` — update `objectReplacer`:
+   - destructure `numericMask` from options
+   - when `isSensitiveKey` is true and `removeMatches` is false, apply
+     `numericMask ?? DEFAULT_NUMERIC_MASK` if `typeof item === 'number'`,
+     otherwise apply `mask` (the existing string mask)
+6. `test/replacers.test.ts` — the tests from step 4 and the existing test at
+   line 320 will now be failing. Update them to assert the new behavior, and add
+   the remaining cases:
+   - `{ password: 123 }` → `password` is `DEFAULT_NUMERIC_MASK` (`9999999999`)
+   - `{ token: 42 }` → `token` is `DEFAULT_NUMERIC_MASK`
+   - custom `numericMask`: `{ password: 99 }` with `numericMask: 0` → `password`
+     is `0`
+   - non-number values under sensitive keys still use `patternMask`: `secret:
+false`, `api_key: ['a', 'b']`, `apikey: { nested: true }`, `token: null`
+     all remain `DEFAULT_PATTERN_MASK`
+   - non-sensitive key with a number value is untouched: `{ count: 5 }` → `{ count: 5 }`
+   - `removeMatches: true` with number-valued sensitive key still removes the
+     field entirely (no mask of either type applied)
+
+   Run `yarn test` to confirm all tests pass.
+
+7. `README.md` — add a `numericMask` row to the Options table directly below
+   `patternMask`, and add a short example showing a number-valued sensitive key
+   being masked.
+
+## Relevant Files
+
+- `docs/plans/009-numeric-mask.md` — new plan for this slice.
+- `src/constants.ts` — add `DEFAULT_NUMERIC_MASK`.
+- `src/types.ts` — add `numericMask` option.
+- `src/replacers.ts` — apply `numericMask` in `objectReplacer`.
+- `test/replacers.test.ts` — new and updated tests for numeric masking behavior.
+- `README.md` — document `numericMask` in the Options table and examples.
+
+## Verification
+
+1. Run `yarn test` — all tests including the new numeric mask cases pass.
+2. Run `yarn test:coverage` — coverage remains at 100%.
+3. Run `yarn lint`.
+4. Run `yarn format:check`.
+5. Run `yarn build` — compiled output includes the new option and constant.
+
+## Decisions
+
+**`numericMask` is `number`-typed, not `string`** — the point is to preserve
+the field's type after sanitization. A string mask would defeat the purpose.
+
+**Default is `9999999999`** — ten nines, the same character-count as the default
+string mask (`**********`), making the two defaults visually consistent and
+easy to explain.
+
+**`objectReplacer` only, not `stringReplacer`** — string input has no concept
+of value type; everything in a string is already a string. The type-preservation
+concern only applies to object traversal.
+
+**`removeMatches` behavior is unchanged** — when removal is requested the field
+is omitted entirely, regardless of value type. No mask (string or numeric) is
+applied.
+
+**Non-number values keep `patternMask`** — `numericMask` is only applied when
+`typeof item === 'number'`. Boolean, object, array, and string values under a
+sensitive key continue to use the string mask as before.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,17 @@ const DEFAULT_FIELD_NAME_PATTERNS = [
 ];
 
 /**
- * A default pattern used when replacing field values.
+ * A default pattern used when replacing string field values.
  */
 const DEFAULT_PATTERN_MASK = '**********';
 
-export { DEFAULT_FIELD_NAME_PATTERNS, DEFAULT_PATTERN_MASK };
+/**
+ * A default mask used when replacing number field values.
+ */
+const DEFAULT_NUMERIC_MASK = 9999999999;
+
+export {
+  DEFAULT_FIELD_NAME_PATTERNS,
+  DEFAULT_NUMERIC_MASK,
+  DEFAULT_PATTERN_MASK,
+};

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -1,5 +1,9 @@
 import { DataSanitizationMatcher, DataSanitizationReplacer } from './types';
-import { DEFAULT_FIELD_NAME_PATTERNS, DEFAULT_PATTERN_MASK } from './constants';
+import {
+  DEFAULT_FIELD_NAME_PATTERNS,
+  DEFAULT_NUMERIC_MASK,
+  DEFAULT_PATTERN_MASK,
+} from './constants';
 import defaultMatchers, { escapePattern } from './matchers';
 
 const buildPatterns = (
@@ -93,6 +97,7 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
 const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const {
     customPatterns,
+    numericMask,
     patternMask,
     removeMatches = false,
     useDefaultPatterns = true,
@@ -141,7 +146,10 @@ const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
 
       if (isSensitiveKey) {
         if (!removeMatches) {
-          nextObject[key] = mask;
+          nextObject[key] =
+            typeof item === 'number'
+              ? (numericMask ?? DEFAULT_NUMERIC_MASK)
+              : mask;
         }
         continue;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ interface DataSanitizationReplacerOptions {
    */
   customPatterns?: string[];
   /**
+   * A number to use as a mask for number-typed field values in place of the
+   * built-in default numeric mask
+   */
+  numericMask?: number;
+  /**
    * A string to use as a data mask in place of the built-in default mask
    */
   patternMask?: string;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 /* local imports */
 import sanitizeData from '../src/index';
 import { DataSanitizationError } from '../src/errors';
-import { DEFAULT_PATTERN_MASK } from '../src/constants';
+import { DEFAULT_NUMERIC_MASK, DEFAULT_PATTERN_MASK } from '../src/constants';
 
 const failingMatcher = (): RegExp => {
   throw new Error('matcher failed');
@@ -92,7 +92,7 @@ describe('DataSanitizationIndexAndErrors', () => {
       // Assert
       expect(output).toEqual([
         { password: DEFAULT_PATTERN_MASK, username: 'bar' },
-        { safe: true, token: DEFAULT_PATTERN_MASK },
+        { safe: true, token: DEFAULT_NUMERIC_MASK },
       ]);
     });
 
@@ -111,7 +111,7 @@ describe('DataSanitizationIndexAndErrors', () => {
       const output = sanitizeData(input) as Record<string, unknown>;
 
       // Assert
-      expect(output.password).toEqual(DEFAULT_PATTERN_MASK);
+      expect(output.password).toEqual(DEFAULT_NUMERIC_MASK);
       expect(output.secret).toEqual(DEFAULT_PATTERN_MASK);
       expect(output.token).toEqual(DEFAULT_PATTERN_MASK);
       expect(output.api_key).toEqual(DEFAULT_PATTERN_MASK);

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 /* local imports */
 import { objectReplacer, stringReplacer } from '../src/replacers';
-import { DEFAULT_PATTERN_MASK } from '../src/constants';
+import { DEFAULT_NUMERIC_MASK, DEFAULT_PATTERN_MASK } from '../src/constants';
 
 describe('DataSanitizationReplacers', () => {
   describe('stringReplacer', () => {
@@ -331,8 +331,8 @@ describe('DataSanitizationReplacers', () => {
         // Act
         const result = objectReplacer(testData) as Record<string, unknown>;
 
-        // Assert
-        expect(result.password).toEqual(DEFAULT_PATTERN_MASK);
+        // Assert — number-typed values get DEFAULT_NUMERIC_MASK; all others get DEFAULT_PATTERN_MASK
+        expect(result.password).toEqual(DEFAULT_NUMERIC_MASK);
         expect(result.secret).toEqual(DEFAULT_PATTERN_MASK);
         expect(result.token).toEqual(DEFAULT_PATTERN_MASK);
         expect(result.api_key).toEqual(DEFAULT_PATTERN_MASK);
@@ -449,6 +449,60 @@ describe('DataSanitizationReplacers', () => {
         expect(result.password).toEqual(DEFAULT_PATTERN_MASK);
         expect(result.username).toEqual('márk');
       });
+
+      it('should mask number-valued sensitive keys with the default numeric mask', () => {
+        // Arrange
+        const testData = { password: 123, username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect(result.password).toEqual(DEFAULT_NUMERIC_MASK);
+        expect(result.username).toEqual('mark');
+      });
+
+      it('should mask number-valued sensitive keys with a custom numericMask', () => {
+        // Arrange
+        const testData = { token: 42, username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, { numericMask: 0 }) as Record<
+          string,
+          unknown
+        >;
+
+        // Assert
+        expect(result.token).toEqual(0);
+        expect(result.username).toEqual('mark');
+      });
+
+      it('should apply numericMask independently of patternMask', () => {
+        // Arrange
+        const testData = { password: 123, secret: 'abc', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          patternMask: '[REDACTED]',
+        }) as Record<string, unknown>;
+
+        // Assert — string value uses patternMask; number value uses DEFAULT_NUMERIC_MASK
+        expect(result.password).toEqual(DEFAULT_NUMERIC_MASK);
+        expect(result.secret).toEqual('[REDACTED]');
+        expect(result.username).toEqual('mark');
+      });
+
+      it('should leave non-sensitive number-valued keys untouched', () => {
+        // Arrange
+        const testData = { count: 5, username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect(result.count).toEqual(5);
+        expect(result.username).toEqual('mark');
+      });
     });
 
     describe('removal', () => {
@@ -503,10 +557,10 @@ describe('DataSanitizationReplacers', () => {
           useDefaultPatterns: false,
         }) as Record<string, unknown>;
 
-        // Assert
+        // Assert — ssn is a number so gets DEFAULT_NUMERIC_MASK despite custom patternMask
         expect(result).toEqual({
           password: 'keep-me',
-          ssn: '[MASKED]',
+          ssn: DEFAULT_NUMERIC_MASK,
           username: 'safe',
         });
       });


### PR DESCRIPTION
## Overview

Adds a `numericMask` option (default `9999999999`) to `objectReplacer` for masking number-typed sensitive field values. Previously, masking a numeric value with the string `patternMask` silently changed the field's type. `numericMask` preserves it.

## Details

- `DEFAULT_NUMERIC_MASK = 9999999999` added to `src/constants.ts` (same length as the default string mask for visual consistency)
- `numericMask?: number` added to `DataSanitizationReplacerOptions` in `src/types.ts`
- `objectReplacer` applies `numericMask ?? DEFAULT_NUMERIC_MASK` when `typeof item === 'number'`; all other value types continue to use `patternMask`
- `patternMask` and `numericMask` are independent options — providing one does not affect the other
- `stringReplacer` is unchanged (no value types in string input)
- 4 new tests; 5 existing assertions updated to reflect the new behavior

## Test Plan

- [x] `yarn test` — 85 tests passing (81 original + 4 new)
- [x] `yarn test:coverage` — 100% statements, branches, functions, lines
- [x] `yarn lint`
- [x] `yarn format:check`
- [x] `yarn build`

## Related

Closes the "Numeric Mask for Number-Typed Sensitive Values" item in `docs/ROADMAP.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `numericMask` option to independently mask numeric-type sensitive values, separate from string-based pattern masking.

* **Documentation**
  * Updated data-sanitization options documentation with examples demonstrating `numericMask` usage for numeric sensitive values.
  * Refined `patternMask` description to clarify its application to matched string field values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->