### PR TITLE
feat: string-value scanning in objectReplacer with scanStringValues opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ dependencies.
   - [Error handling](#error-handling)
   - [How it works](#how-it-works)
   - [Performance](#performance)
-    - [Object workloads](#object-workloads)
-    - [String workloads](#string-workloads)
-    - [High pattern counts](#high-pattern-counts)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -325,59 +322,36 @@ request/response objects, and similar data before they leave your application.
 It is not designed for streaming pipelines or bulk batch processing of large
 files.
 
-### Object workloads
+String-value scanning (`scanStringValues: true`, the default) adds overhead
+on object workloads. The cost depends on how many non-sensitive string fields
+the input has and how long they are. Rough throughput on a modern laptop
+(Apple M-series, Node.js 22):
 
-String-value scanning (`scanStringValues: true`, the default) checks every
-non-sensitive string field for embedded patterns. This is the recommended
-setting — it catches credentials embedded in log messages and similar
-free-text fields. It does carry a performance cost on object workloads.
+| Workload                                       | ops/s    | ms/call | scan overhead |
+| ---------------------------------------------- | -------- | ------- | ------------- |
+| Shallow object (1 sensitive key)               | ~243,000 | ~0.004  | ~55%          |
+| Log object, stack trace with credentials       | ~79,000  | ~0.013  | ~80%          |
+| Log object, clean stack trace                  | ~199,000 | ~0.005  | ~49%          |
+| Object with 10KB non-sensitive string          | ~143,000 | ~0.007  | ~76%          |
+| Large flat object (50 fields, 1 sensitive key) | ~69,000  | ~0.015  | ~15%          |
+| Array (1,000 items, 1 sensitive key each)      | ~2,043   | ~0.49   | ~4%           |
+| Array (1,000,000 items, 1 sensitive key each)  | ~1.7     | ~574    | ~4%           |
 
-Rough throughput on a modern laptop (Apple M-series, Node.js 22):
-
-| Workload                                                         | `scanStringValues: true`     | `scanStringValues: false`    |
-| ---------------------------------------------------------------- | ---------------------------- | ---------------------------- |
-| Shallow object (4 fields, 1 sensitive key)                       | ~249,000 ops/s (~4 µs/call)  | ~558,000 ops/s (~2 µs/call)  |
-| Deeply nested object (sensitive key × 5 levels)                  | ~208,000 ops/s (~5 µs/call)  | ~389,000 ops/s (~3 µs/call)  |
-| Object with embedded credential in string value                  | ~106,000 ops/s (~9 µs/call)  | ~399,000 ops/s (~3 µs/call)  |
-| Many embedded matches (20 fields, all strings contain a pattern) | ~13,000 ops/s (~76 µs/call)  | —                            |
-| Large flat object (50 fields, 1 sensitive key)                   | ~72,000 ops/s (~14 µs/call)  | ~91,000 ops/s (~11 µs/call)  |
-| Large array (1,000 objects, 1 sensitive key each)                | ~2,200 ops/s (~0.45 ms/call) | ~2,400 ops/s (~0.42 ms/call) |
-| Very large array (100,000 objects, 1 sensitive key)              | ~19 ops/s (~54 ms/call)      | ~21 ops/s (~48 ms/call)      |
-
-The "Many embedded matches" row shows the worst case: every scanned string
-value actually contains a sensitive pattern and runs the full regex suite.
+Array workloads pay ~2–4% overhead regardless of size — the per-item
+pre-filter cost is negligible. The cost is most visible on individual objects
+with long non-sensitive string values such as stack traces or large text
+fields; a single 10KB non-sensitive string value incurs ~76% overhead.
 
 Set `scanStringValues: false` to recover the pre-scanning performance when
 you control your data structure and know sensitive values only appear on
 sensitive-named keys.
 
-### String workloads
-
-String input always scans the full string regardless of `scanStringValues`.
-The option only affects the object traversal path.
-
-| Workload                                        | Throughput                   |
-| ----------------------------------------------- | ---------------------------- |
-| Long JSON string (50 sensitive key/value pairs) | ~7,100 ops/s (~0.14 ms/call) |
-
-### High pattern counts
-
-Pattern count affects object workloads proportionally when
-`scanStringValues: true`. With default patterns disabled:
-
-| Workload                                               | Throughput                  |
-| ------------------------------------------------------ | --------------------------- |
-| 50-field object, 50 custom patterns (no string match)  | ~23,000 ops/s (~44 µs/call) |
-| 3-field object, 50 custom patterns (no string match)   | ~55,000 ops/s (~18 µs/call) |
-| 3-field object, 50 custom patterns (string value hits) | ~18,000 ops/s (~55 µs/call) |
-
-To run the benchmark suite:
+For full benchmark tables, charts, and scaling analysis see
+[docs/performance.md](docs/performance.md). To run the suite:
 
 ```bash
 yarn bench
 ```
-
-Benchmarks live in `bench/sanitize-data.bench.ts`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -334,15 +334,15 @@ free-text fields. It does carry a performance cost on object workloads.
 
 Rough throughput on a modern laptop (Apple M-series, Node.js 22):
 
-| Workload                                                         | `scanStringValues: true` | `scanStringValues: false` |
-| ---------------------------------------------------------------- | ------------------------ | ------------------------- |
-| Shallow object (4 fields, 1 sensitive key)                       | ~249,000 ops/s           | ~558,000 ops/s            |
-| Deeply nested object (sensitive key × 5 levels)                  | ~208,000 ops/s           | ~389,000 ops/s            |
-| Object with embedded credential in string value                  | ~106,000 ops/s           | ~399,000 ops/s            |
-| Many embedded matches (20 fields, all strings contain a pattern) | ~13,000 ops/s            | —                         |
-| Large flat object (50 fields, 1 sensitive key)                   | ~72,000 ops/s            | ~91,000 ops/s             |
-| Large array (1,000 objects, 1 sensitive key each)                | ~2,200 ops/s             | ~2,400 ops/s              |
-| Very large array (100,000 objects, 1 sensitive key)              | ~19 ops/s                | ~21 ops/s                 |
+| Workload                                                         | `scanStringValues: true`     | `scanStringValues: false`    |
+| ---------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| Shallow object (4 fields, 1 sensitive key)                       | ~249,000 ops/s (~4 µs/call)  | ~558,000 ops/s (~2 µs/call)  |
+| Deeply nested object (sensitive key × 5 levels)                  | ~208,000 ops/s (~5 µs/call)  | ~389,000 ops/s (~3 µs/call)  |
+| Object with embedded credential in string value                  | ~106,000 ops/s (~9 µs/call)  | ~399,000 ops/s (~3 µs/call)  |
+| Many embedded matches (20 fields, all strings contain a pattern) | ~13,000 ops/s (~76 µs/call)  | —                            |
+| Large flat object (50 fields, 1 sensitive key)                   | ~72,000 ops/s (~14 µs/call)  | ~91,000 ops/s (~11 µs/call)  |
+| Large array (1,000 objects, 1 sensitive key each)                | ~2,200 ops/s (~0.45 ms/call) | ~2,400 ops/s (~0.42 ms/call) |
+| Very large array (100,000 objects, 1 sensitive key)              | ~19 ops/s (~54 ms/call)      | ~21 ops/s (~48 ms/call)      |
 
 The "Many embedded matches" row shows the worst case: every scanned string
 value actually contains a sensitive pattern and runs the full regex suite.
@@ -356,20 +356,20 @@ sensitive-named keys.
 String input always scans the full string regardless of `scanStringValues`.
 The option only affects the object traversal path.
 
-| Workload                                        | Throughput   |
-| ----------------------------------------------- | ------------ |
-| Long JSON string (50 sensitive key/value pairs) | ~7,100 ops/s |
+| Workload                                        | Throughput                   |
+| ----------------------------------------------- | ---------------------------- |
+| Long JSON string (50 sensitive key/value pairs) | ~7,100 ops/s (~0.14 ms/call) |
 
 ### High pattern counts
 
 Pattern count affects object workloads proportionally when
 `scanStringValues: true`. With default patterns disabled:
 
-| Workload                                               | Throughput    |
-| ------------------------------------------------------ | ------------- |
-| 50-field object, 50 custom patterns (no string match)  | ~23,000 ops/s |
-| 3-field object, 50 custom patterns (no string match)   | ~55,000 ops/s |
-| 3-field object, 50 custom patterns (string value hits) | ~18,000 ops/s |
+| Workload                                               | Throughput                  |
+| ------------------------------------------------------ | --------------------------- |
+| 50-field object, 50 custom patterns (no string match)  | ~23,000 ops/s (~44 µs/call) |
+| 3-field object, 50 custom patterns (no string match)   | ~55,000 ops/s (~18 µs/call) |
+| 3-field object, 50 custom patterns (string value hits) | ~18,000 ops/s (~55 µs/call) |
 
 To run the benchmark suite:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ dependencies.
   - [Custom patterns and matchers](#custom-patterns-and-matchers)
   - [Error handling](#error-handling)
   - [How it works](#how-it-works)
+  - [Performance](#performance)
+    - [Object workloads](#object-workloads)
+    - [String workloads](#string-workloads)
+    - [High pattern counts](#high-pattern-counts)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -185,15 +189,16 @@ sanitizeData(patient, {
 
 ## Options
 
-| Option               | Type                        | Default      | Description                                         |
-| -------------------- | --------------------------- | ------------ | --------------------------------------------------- |
-| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values  |
-| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values  |
-| `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking   |
-| `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match             |
-| `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats |
-| `useDefaultPatterns` | `boolean`                   | `true`       | Whether to include the built-in default patterns    |
-| `useDefaultMatchers` | `boolean`                   | `true`       | Whether to include the built-in default matchers    |
+| Option               | Type                        | Default      | Description                                                                        |
+| -------------------- | --------------------------- | ------------ | ---------------------------------------------------------------------------------- |
+| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values                                 |
+| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values                                 |
+| `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking                                  |
+| `scanStringValues`   | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns (object input only) |
+| `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match                                            |
+| `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                |
+| `useDefaultPatterns` | `boolean`                   | `true`       | Whether to include the built-in default patterns                                   |
+| `useDefaultMatchers` | `boolean`                   | `true`       | Whether to include the built-in default matchers                                   |
 
 ## Default patterns
 
@@ -306,9 +311,12 @@ original input payload.
    Non-plain object instances are preserved without modification to avoid
    corrupting their prototypes.
 4. **Null input** is accepted and returns `null`.
-5. Each configured pattern is matched case-insensitively against object keys.
-   For string input, each configured pattern is tested against each matcher to
-   produce regex instances that find and replace sensitive field values.
+5. **For object input**, each configured pattern is matched case-insensitively
+   against keys. String values on non-sensitive keys are also scanned for
+   embedded patterns by default (`scanStringValues: true`), which catches
+   credentials embedded in log messages or other free-text fields. **For string
+   input**, each pattern is tested against each matcher to produce regex
+   instances that find and replace sensitive values in the string directly.
 
 ## Performance
 
@@ -317,14 +325,51 @@ request/response objects, and similar data before they leave your application.
 It is not designed for streaming pipelines or bulk batch processing of large
 files.
 
+### Object workloads
+
+String-value scanning (`scanStringValues: true`, the default) checks every
+non-sensitive string field for embedded patterns. This is the recommended
+setting — it catches credentials embedded in log messages and similar
+free-text fields. It does carry a performance cost on object workloads.
+
 Rough throughput on a modern laptop (Apple M-series, Node.js 22):
 
-| Workload                                          | Throughput     |
-| ------------------------------------------------- | -------------- |
-| Shallow object (4 fields, 1 sensitive key)        | ~563,000 ops/s |
-| Deeply nested object (sensitive key × 5 levels)   | ~354,000 ops/s |
-| Large array (1,000 objects, 1 sensitive key each) | ~2,340 ops/s   |
-| Long JSON string (50 sensitive key/value pairs)   | ~6,760 ops/s   |
+| Workload                                                         | `scanStringValues: true` | `scanStringValues: false` |
+| ---------------------------------------------------------------- | ------------------------ | ------------------------- |
+| Shallow object (4 fields, 1 sensitive key)                       | ~249,000 ops/s           | ~558,000 ops/s            |
+| Deeply nested object (sensitive key × 5 levels)                  | ~208,000 ops/s           | ~389,000 ops/s            |
+| Object with embedded credential in string value                  | ~106,000 ops/s           | ~399,000 ops/s            |
+| Many embedded matches (20 fields, all strings contain a pattern) | ~13,000 ops/s            | —                         |
+| Large flat object (50 fields, 1 sensitive key)                   | ~72,000 ops/s            | ~91,000 ops/s             |
+| Large array (1,000 objects, 1 sensitive key each)                | ~2,200 ops/s             | ~2,400 ops/s              |
+| Very large array (100,000 objects, 1 sensitive key)              | ~19 ops/s                | ~21 ops/s                 |
+
+The "Many embedded matches" row shows the worst case: every scanned string
+value actually contains a sensitive pattern and runs the full regex suite.
+
+Set `scanStringValues: false` to recover the pre-scanning performance when
+you control your data structure and know sensitive values only appear on
+sensitive-named keys.
+
+### String workloads
+
+String input always scans the full string regardless of `scanStringValues`.
+The option only affects the object traversal path.
+
+| Workload                                        | Throughput   |
+| ----------------------------------------------- | ------------ |
+| Long JSON string (50 sensitive key/value pairs) | ~7,100 ops/s |
+
+### High pattern counts
+
+Pattern count affects object workloads proportionally when
+`scanStringValues: true`. With default patterns disabled:
+
+| Workload                                               | Throughput    |
+| ------------------------------------------------------ | ------------- |
+| 50-field object, 50 custom patterns (no string match)  | ~23,000 ops/s |
+| 3-field object, 50 custom patterns (no string match)   | ~55,000 ops/s |
+| 3-field object, 50 custom patterns (string value hits) | ~18,000 ops/s |
 
 To run the benchmark suite:
 
@@ -332,9 +377,7 @@ To run the benchmark suite:
 yarn bench
 ```
 
-Benchmarks live in `bench/sanitize-data.bench.ts`. When the string-value
-scanning and parser-first JSON string handling roadmap items are implemented,
-add benchmark cases to that suite as part of those changes.
+Benchmarks live in `bench/sanitize-data.bench.ts`.
 
 ## Contributing
 

--- a/bench/sanitize-data.bench.ts
+++ b/bench/sanitize-data.bench.ts
@@ -1,15 +1,17 @@
 /**
- * Benchmarks for sanitizeData covering four representative workloads.
+ * Benchmarks for sanitizeData.
  *
  * Run with: yarn bench
  *
- * These benchmarks establish a baseline for the current object-key and
- * string-matcher approach. Future items that affect this baseline:
- *   - String-value scanning in objectReplacer (per-field string matching on
- *     non-sensitive keys will increase per-object cost)
- *   - Parser-first JSON string handling (JSON.parse + objectReplacer path will
- *     change the string sanitization cost profile)
- * Update this suite as part of implementing those changes.
+ * Cases marked "scanStringValues disabled" run with the opt-out flag so you
+ * can directly compare the cost of string-value scanning on the same input.
+ * The regression on object workloads is the cost of testing every non-sensitive
+ * string value against the OR pre-filter; string and array workloads are
+ * unaffected because they do not use objectReplacer.
+ *
+ * Update this suite as part of implementing parser-first JSON string handling
+ * (JSON.parse + objectReplacer path will change the string sanitization cost
+ * profile).
  */
 
 import { bench, describe } from 'vitest';
@@ -27,6 +29,19 @@ describe('sanitizeData — shallow object', () => {
 
   bench('mask one sensitive key in a 4-field object', () => {
     sanitizeData(input);
+  });
+});
+
+describe('sanitizeData — shallow object, scanStringValues disabled', () => {
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    email: 'user@example.com',
+    region: 'us-east-1',
+    username: 'mark',
+  };
+
+  bench('mask one sensitive key in a 4-field object (no string scan)', () => {
+    sanitizeData(input, { scanStringValues: false });
   });
 });
 
@@ -65,6 +80,44 @@ describe('sanitizeData — large array', () => {
   });
 });
 
+describe('sanitizeData — object with embedded credentials', () => {
+  const input = {
+    log_message: `request failed: api_key=${SENSITIVE_STRING_VALUE}`,
+    request_id: 'req-abc-123',
+    user_id: 'usr-456',
+  };
+
+  bench('3-field object with embedded sensitive pattern in string value', () => {
+    sanitizeData(input);
+  });
+});
+
+describe('sanitizeData — object with embedded credentials, scanStringValues disabled', () => {
+  const input = {
+    log_message: `request failed: api_key=${SENSITIVE_STRING_VALUE}`,
+    request_id: 'req-abc-123',
+    user_id: 'usr-456',
+  };
+
+  bench('3-field object with embedded sensitive pattern (no string scan)', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — many embedded matches', () => {
+  const input = Object.fromEntries([
+    ['api_key', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 20 }, (_, i) => [
+      `log_${i}`,
+      `api_key=${SENSITIVE_STRING_VALUE}`,
+    ]),
+  ]) as Record<string, unknown>;
+
+  bench('mask 1 sensitive key and 20 string values containing embedded patterns', () => {
+    sanitizeData(input);
+  });
+});
+
 describe('sanitizeData — long string', () => {
   const pair = (i: number) =>
     `"password_${i}":"${SENSITIVE_STRING_VALUE}","safe_${i}":"value"`;
@@ -72,5 +125,76 @@ describe('sanitizeData — long string', () => {
 
   bench('mask 50 sensitive key/value pairs in a JSON string', () => {
     sanitizeData(input);
+  });
+});
+
+describe('sanitizeData — large flat object', () => {
+  const input = Object.fromEntries([
+    ['api_key', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
+  ]) as Record<string, unknown>;
+
+  bench('mask one sensitive key in a 50-field object', () => {
+    sanitizeData(input);
+  });
+});
+
+describe('sanitizeData — large flat object, scanStringValues disabled', () => {
+  const input = Object.fromEntries([
+    ['api_key', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
+  ]) as Record<string, unknown>;
+
+  bench('mask one sensitive key in a 50-field object (no string scan)', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — wide object with many patterns', () => {
+  const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
+  const input = Object.fromEntries([
+    ['custom_0', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
+  ]) as Record<string, unknown>;
+
+  bench('50-field object scanned against 50 custom patterns', () => {
+    sanitizeData(input, { customPatterns, useDefaultPatterns: false });
+  });
+});
+
+describe('sanitizeData — very large array', () => {
+  const input = Array.from({ length: 100_000 }, (_, i) => ({
+    id: i,
+    token: SENSITIVE_STRING_VALUE,
+    username: `user-${i}`,
+  }));
+
+  bench('mask one sensitive key across 100,000 array items', () => {
+    sanitizeData(input);
+  });
+});
+
+describe('sanitizeData — 50 custom patterns', () => {
+  const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    region: 'us-east-1',
+    username: 'mark',
+  };
+
+  bench('mask with 50 custom patterns (default patterns disabled)', () => {
+    sanitizeData(input, { customPatterns, useDefaultPatterns: false });
+  });
+});
+
+describe('sanitizeData — 50 custom patterns with string match', () => {
+  const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
+  const input = {
+    log: 'custom_0=hunter2&other=safe',
+    username: 'mark',
+  };
+
+  bench('scan string value through 50-pattern suite', () => {
+    sanitizeData(input, { customPatterns, useDefaultPatterns: false });
   });
 });

--- a/bench/sanitize-data.bench.ts
+++ b/bench/sanitize-data.bench.ts
@@ -3,15 +3,24 @@
  *
  * Run with: yarn bench
  *
- * Cases marked "scanStringValues disabled" run with the opt-out flag so you
- * can directly compare the cost of string-value scanning on the same input.
- * The regression on object workloads is the cost of testing every non-sensitive
- * string value against the OR pre-filter; string and array workloads are
- * unaffected because they do not use objectReplacer.
+ * Each group includes a "scanStringValues disabled" bench where the option
+ * meaningfully changes behavior (i.e. the input has non-sensitive string
+ * values). Cases without a disabled variant either have no non-sensitive
+ * strings to scan (all-sensitive-key inputs) or use string input, which is
+ * unaffected by the option.
  *
- * Update this suite as part of implementing parser-first JSON string handling
- * (JSON.parse + objectReplacer path will change the string sanitization cost
- * profile).
+ * Array sizes span 1k / 10k / 100k / 1M items (one order of magnitude between
+ * each step) to reveal whether throughput scales linearly with item count.
+ * Both simple (3-field, 1 sensitive) and complex (10-field, 5 sensitive) item
+ * shapes are included so per-item work is also varied.
+ *
+ * Additional groups cover:
+ * - Cold start vs warm cache (regex compile cost on first call)
+ * - removeMatches (mask vs delete) across object and string inputs
+ * - Large non-sensitive string values (~10KB pre-filter cost)
+ * - Object with an array-of-strings field (per-item string scan)
+ * - String input variants (form-encoded, escaped JSON)
+ * - Deeply nested objects with many non-sensitive strings per level
  */
 
 import { bench, describe } from 'vitest';
@@ -19,7 +28,72 @@ import sanitizeData from '../src/index';
 
 const SENSITIVE_STRING_VALUE = 'super-secret-value-that-should-be-masked';
 
-describe('sanitizeData — shallow object', () => {
+// ~10KB non-sensitive string value — worst-case pre-filter scan cost
+const LARGE_CLEAN_STRING = 'x'.repeat(10_000);
+
+const FORM_ENCODED_STRING = `api_key=${SENSITIVE_STRING_VALUE}&region=us-east-1&username=mark`;
+
+// Inner JSON is backslash-escaped, exercising escapedJsonMatcher
+const ESCAPED_JSON_STRING = `{"event":"auth","data":"{\\"api_key\\":\\"${SENSITIVE_STRING_VALUE}\\",\\"user\\":\\"mark\\"}"}`;
+
+const LOGS_CLEAN = Array.from(
+  { length: 100 },
+  (_, i) => `log entry ${i}: request processed`,
+);
+const LOGS_WITH_MATCH = Array.from({ length: 100 }, (_, i) =>
+  i === 0
+    ? `api_key=${SENSITIVE_STRING_VALUE}`
+    : `log entry ${i}: request processed`,
+);
+
+// 5 nesting levels, each with 10 non-sensitive string fields + 1 nested key;
+// innermost level has 10 non-sensitive strings + 1 sensitive key
+const buildDeepNestedManySafe = (): object => {
+  let inner: Record<string, unknown> = Object.fromEntries([
+    ['api_key', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 10 }, (_, i) => [
+      `description_${i}`,
+      `safe leaf value ${i}`,
+    ]),
+  ]);
+  for (let d = 0; d < 5; d++) {
+    inner = Object.fromEntries([
+      ...Array.from({ length: 10 }, (_, i) => [
+        `safe_str_${i}`,
+        `level ${d} field ${i} safe text`,
+      ]),
+      ['nested', inner],
+    ]);
+  }
+  return inner;
+};
+const DEEP_NESTED_MANY_SAFE = buildDeepNestedManySafe();
+
+const STACK_TRACE_WITH_SECRETS = [
+  `Error: upstream auth failed — api_key=${SENSITIVE_STRING_VALUE}`,
+  '    at authenticate (/app/src/auth/service.js:89:15)',
+  '    at processRequest (/app/src/handlers/api.js:134:20)',
+  '    at middleware (/app/src/middleware/auth.js:57:11)',
+  '    at Layer.handle (/app/node_modules/express/lib/router/layer.js:95:5)',
+  '    at next (/app/node_modules/express/lib/router/route.js:137:13)',
+  '    at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)',
+].join('\n');
+
+const STACK_TRACE_CLEAN = [
+  'Error: upstream auth failed — connection timeout',
+  '    at authenticate (/app/src/auth/service.js:89:15)',
+  '    at processRequest (/app/src/handlers/api.js:134:20)',
+  '    at middleware (/app/src/middleware/auth.js:57:11)',
+  '    at Layer.handle (/app/node_modules/express/lib/router/layer.js:95:5)',
+  '    at next (/app/node_modules/express/lib/router/route.js:137:13)',
+  '    at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Shallow object (4 fields)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — shallow object, 1 sensitive key', () => {
   const input = {
     api_key: SENSITIVE_STRING_VALUE,
     email: 'user@example.com',
@@ -27,25 +101,32 @@ describe('sanitizeData — shallow object', () => {
     username: 'mark',
   };
 
-  bench('mask one sensitive key in a 4-field object', () => {
+  bench('default', () => {
     sanitizeData(input);
   });
-});
-
-describe('sanitizeData — shallow object, scanStringValues disabled', () => {
-  const input = {
-    api_key: SENSITIVE_STRING_VALUE,
-    email: 'user@example.com',
-    region: 'us-east-1',
-    username: 'mark',
-  };
-
-  bench('mask one sensitive key in a 4-field object (no string scan)', () => {
+  bench('scanStringValues disabled', () => {
     sanitizeData(input, { scanStringValues: false });
   });
 });
 
-describe('sanitizeData — deeply nested object', () => {
+describe('sanitizeData — shallow object, 4 sensitive keys', () => {
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    password: SENSITIVE_STRING_VALUE,
+    secret: SENSITIVE_STRING_VALUE,
+    token: SENSITIVE_STRING_VALUE,
+  };
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deeply nested object (5 levels, multiple sensitive keys)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — deeply nested object (5 levels)', () => {
   const input = {
     level1: {
       level2: {
@@ -63,48 +144,72 @@ describe('sanitizeData — deeply nested object', () => {
     password: SENSITIVE_STRING_VALUE,
   };
 
-  bench('mask sensitive keys at 5 nesting levels', () => {
+  bench('default', () => {
     sanitizeData(input);
   });
-});
-
-describe('sanitizeData — large array', () => {
-  const input = Array.from({ length: 1000 }, (_, i) => ({
-    id: i,
-    token: SENSITIVE_STRING_VALUE,
-    username: `user-${i}`,
-  }));
-
-  bench('mask one sensitive key across 1000 array items', () => {
-    sanitizeData(input);
-  });
-});
-
-describe('sanitizeData — object with embedded credentials', () => {
-  const input = {
-    log_message: `request failed: api_key=${SENSITIVE_STRING_VALUE}`,
-    request_id: 'req-abc-123',
-    user_id: 'usr-456',
-  };
-
-  bench('3-field object with embedded sensitive pattern in string value', () => {
-    sanitizeData(input);
-  });
-});
-
-describe('sanitizeData — object with embedded credentials, scanStringValues disabled', () => {
-  const input = {
-    log_message: `request failed: api_key=${SENSITIVE_STRING_VALUE}`,
-    request_id: 'req-abc-123',
-    user_id: 'usr-456',
-  };
-
-  bench('3-field object with embedded sensitive pattern (no string scan)', () => {
+  bench('scanStringValues disabled', () => {
     sanitizeData(input, { scanStringValues: false });
   });
 });
 
-describe('sanitizeData — many embedded matches', () => {
+// ---------------------------------------------------------------------------
+// Log object — embedded credentials
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — log object, embedded credential in string value', () => {
+  const input = {
+    log_message: `request failed: api_key=${SENSITIVE_STRING_VALUE}`,
+    request_id: 'req-abc-123',
+    user_id: 'usr-456',
+  };
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — log object, stack trace containing credentials', () => {
+  const input = {
+    environment: 'production',
+    requestId: 'req-abc-123',
+    service: 'auth-service',
+    stack: STACK_TRACE_WITH_SECRETS,
+    userId: 'usr-456',
+  };
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — log object, clean stack trace', () => {
+  const input = {
+    environment: 'production',
+    requestId: 'req-abc-123',
+    service: 'auth-service',
+    stack: STACK_TRACE_CLEAN,
+    userId: 'usr-456',
+  };
+
+  bench('default (pre-filter fast-exit)', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Many embedded matches
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — many embedded matches (21 fields)', () => {
   const input = Object.fromEntries([
     ['api_key', SENSITIVE_STRING_VALUE],
     ...Array.from({ length: 20 }, (_, i) => [
@@ -113,68 +218,239 @@ describe('sanitizeData — many embedded matches', () => {
     ]),
   ]) as Record<string, unknown>;
 
-  bench('mask 1 sensitive key and 20 string values containing embedded patterns', () => {
+  bench('default', () => {
     sanitizeData(input);
   });
 });
 
-describe('sanitizeData — long string', () => {
-  const pair = (i: number) =>
-    `"password_${i}":"${SENSITIVE_STRING_VALUE}","safe_${i}":"value"`;
-  const input = `{${Array.from({ length: 50 }, (_, i) => pair(i)).join(',')}}`;
+// ---------------------------------------------------------------------------
+// Large flat object (50 fields)
+// ---------------------------------------------------------------------------
 
-  bench('mask 50 sensitive key/value pairs in a JSON string', () => {
-    sanitizeData(input);
-  });
-});
-
-describe('sanitizeData — large flat object', () => {
+describe('sanitizeData — large flat object, 1 sensitive key', () => {
   const input = Object.fromEntries([
     ['api_key', SENSITIVE_STRING_VALUE],
     ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
   ]) as Record<string, unknown>;
 
-  bench('mask one sensitive key in a 50-field object', () => {
+  bench('default', () => {
     sanitizeData(input);
   });
-});
-
-describe('sanitizeData — large flat object, scanStringValues disabled', () => {
-  const input = Object.fromEntries([
-    ['api_key', SENSITIVE_STRING_VALUE],
-    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
-  ]) as Record<string, unknown>;
-
-  bench('mask one sensitive key in a 50-field object (no string scan)', () => {
+  bench('scanStringValues disabled', () => {
     sanitizeData(input, { scanStringValues: false });
   });
 });
 
-describe('sanitizeData — wide object with many patterns', () => {
-  const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
+describe('sanitizeData — large flat object, 5 sensitive keys', () => {
   const input = Object.fromEntries([
-    ['custom_0', SENSITIVE_STRING_VALUE],
-    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
+    ...Array.from({ length: 5 }, (_, i) => [
+      `password_${i}`,
+      SENSITIVE_STRING_VALUE,
+    ]),
+    ...Array.from({ length: 45 }, (_, i) => [`field_${i}`, `value_${i}`]),
   ]) as Record<string, unknown>;
 
-  bench('50-field object scanned against 50 custom patterns', () => {
-    sanitizeData(input, { customPatterns, useDefaultPatterns: false });
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
   });
 });
 
-describe('sanitizeData — very large array', () => {
+// ---------------------------------------------------------------------------
+// Array — simple items (3 fields: id, token, username; 1 sensitive key)
+// Sizes: 1k / 10k / 100k / 1M / 10M
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — array, simple items (1 sensitive), 1,000 items', () => {
+  const input = Array.from({ length: 1_000 }, (_, i) => ({
+    id: i,
+    token: SENSITIVE_STRING_VALUE,
+    username: `user-${i}`,
+  }));
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — array, simple items (1 sensitive), 10,000 items', () => {
+  const input = Array.from({ length: 10_000 }, (_, i) => ({
+    id: i,
+    token: SENSITIVE_STRING_VALUE,
+    username: `user-${i}`,
+  }));
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — array, simple items (1 sensitive), 100,000 items', () => {
   const input = Array.from({ length: 100_000 }, (_, i) => ({
     id: i,
     token: SENSITIVE_STRING_VALUE,
     username: `user-${i}`,
   }));
 
-  bench('mask one sensitive key across 100,000 array items', () => {
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — array, simple items (1 sensitive), 1,000,000 items', () => {
+  const input = Array.from({ length: 1_000_000 }, (_, i) => ({
+    id: i,
+    token: SENSITIVE_STRING_VALUE,
+    username: `user-${i}`,
+  }));
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Array — complex items (10 fields: 5 sensitive + 5 non-sensitive)
+// Sizes: 1k / 10k / 100k / 1M
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — array, complex items (5 sensitive), 1,000 items', () => {
+  const input = Array.from({ length: 1_000 }, (_, i) =>
+    Object.fromEntries([
+      ...Array.from({ length: 5 }, (_k, j) => [
+        `password_${j}`,
+        SENSITIVE_STRING_VALUE,
+      ]),
+      ['email', `user-${i}@example.com`],
+      ['id', i],
+      ['region', 'us-east-1'],
+      ['status', 'active'],
+      ['username', `user-${i}`],
+    ]),
+  );
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — array, complex items (5 sensitive), 10,000 items', () => {
+  const input = Array.from({ length: 10_000 }, (_, i) =>
+    Object.fromEntries([
+      ...Array.from({ length: 5 }, (_k, j) => [
+        `password_${j}`,
+        SENSITIVE_STRING_VALUE,
+      ]),
+      ['email', `user-${i}@example.com`],
+      ['id', i],
+      ['region', 'us-east-1'],
+      ['status', 'active'],
+      ['username', `user-${i}`],
+    ]),
+  );
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — array, complex items (5 sensitive), 100,000 items', () => {
+  const input = Array.from({ length: 100_000 }, (_, i) =>
+    Object.fromEntries([
+      ...Array.from({ length: 5 }, (_k, j) => [
+        `password_${j}`,
+        SENSITIVE_STRING_VALUE,
+      ]),
+      ['email', `user-${i}@example.com`],
+      ['id', i],
+      ['region', 'us-east-1'],
+      ['status', 'active'],
+      ['username', `user-${i}`],
+    ]),
+  );
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — array, complex items (5 sensitive), 1,000,000 items', () => {
+  const input = Array.from({ length: 1_000_000 }, (_, i) =>
+    Object.fromEntries([
+      ...Array.from({ length: 5 }, (_k, j) => [
+        `password_${j}`,
+        SENSITIVE_STRING_VALUE,
+      ]),
+      ['email', `user-${i}@example.com`],
+      ['id', i],
+      ['region', 'us-east-1'],
+      ['status', 'active'],
+      ['username', `user-${i}`],
+    ]),
+  );
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Long JSON string (string input; scanStringValues has no effect)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — long JSON string', () => {
+  const pair = (i: number) =>
+    `"password_${i}":"${SENSITIVE_STRING_VALUE}","safe_${i}":"value"`;
+  const input = `{${Array.from({ length: 50 }, (_, i) => pair(i)).join(',')}}`;
+
+  bench('default', () => {
     sanitizeData(input);
   });
 });
 
-describe('sanitizeData — 50 custom patterns', () => {
+// ---------------------------------------------------------------------------
+// High pattern counts (50 custom patterns, default patterns disabled)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — 50 custom patterns, 50-field object', () => {
+  const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
+  const input = Object.fromEntries([
+    ['custom_0', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
+  ]) as Record<string, unknown>;
+
+  bench('default', () => {
+    sanitizeData(input, { customPatterns, useDefaultPatterns: false });
+  });
+});
+
+describe('sanitizeData — 50 custom patterns, 3-field object (no string match)', () => {
   const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
   const input = {
     api_key: SENSITIVE_STRING_VALUE,
@@ -182,19 +458,181 @@ describe('sanitizeData — 50 custom patterns', () => {
     username: 'mark',
   };
 
-  bench('mask with 50 custom patterns (default patterns disabled)', () => {
+  bench('default', () => {
     sanitizeData(input, { customPatterns, useDefaultPatterns: false });
   });
 });
 
-describe('sanitizeData — 50 custom patterns with string match', () => {
+describe('sanitizeData — 50 custom patterns, 3-field object (string value hit)', () => {
   const customPatterns = Array.from({ length: 50 }, (_, i) => `custom_${i}`);
   const input = {
     log: 'custom_0=hunter2&other=safe',
     username: 'mark',
   };
 
-  bench('scan string value through 50-pattern suite', () => {
+  bench('default', () => {
     sanitizeData(input, { customPatterns, useDefaultPatterns: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cold start vs warm cache
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — cold start vs warm cache (3-field object)', () => {
+  let n = 0;
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    region: 'us-east-1',
+    username: 'mark',
+  };
+
+  bench('warm cache (same options each call)', () => {
+    sanitizeData(input);
+  });
+  // Each call uses a unique customPattern, forcing a fresh regex compile and
+  // cache insertion — measures first-call overhead with no warmup benefit.
+  bench('cold start (unique options per call)', () => {
+    sanitizeData(input, { customPatterns: [`__cold_${n++}`] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeMatches: mask vs remove
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — removeMatches, shallow object (4 fields)', () => {
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    email: 'user@example.com',
+    region: 'us-east-1',
+    username: 'mark',
+  };
+
+  bench('mask (default)', () => {
+    sanitizeData(input);
+  });
+  bench('remove', () => {
+    sanitizeData(input, { removeMatches: true });
+  });
+});
+
+describe('sanitizeData — removeMatches, large flat object (50 fields)', () => {
+  const input = Object.fromEntries([
+    ['api_key', SENSITIVE_STRING_VALUE],
+    ...Array.from({ length: 49 }, (_, i) => [`field_${i}`, `value_${i}`]),
+  ]) as Record<string, unknown>;
+
+  bench('mask (default)', () => {
+    sanitizeData(input);
+  });
+  bench('remove', () => {
+    sanitizeData(input, { removeMatches: true });
+  });
+});
+
+describe('sanitizeData — removeMatches, array (1,000 items, 1 sensitive)', () => {
+  const input = Array.from({ length: 1_000 }, (_, i) => ({
+    id: i,
+    token: SENSITIVE_STRING_VALUE,
+    username: `user-${i}`,
+  }));
+
+  bench('mask (default)', () => {
+    sanitizeData(input);
+  });
+  bench('remove', () => {
+    sanitizeData(input, { removeMatches: true });
+  });
+});
+
+describe('sanitizeData — removeMatches, form-encoded string', () => {
+  bench('mask (default)', () => {
+    sanitizeData(FORM_ENCODED_STRING);
+  });
+  bench('remove', () => {
+    sanitizeData(FORM_ENCODED_STRING, { removeMatches: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Large non-sensitive string value (~10KB)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — large non-sensitive string value (10KB)', () => {
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    report: LARGE_CLEAN_STRING,
+  };
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Object with array-of-strings field (100 log lines)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — object with array-of-strings, 100 clean log lines', () => {
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    logs: LOGS_CLEAN,
+  };
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+});
+
+describe('sanitizeData — object with array-of-strings, 1 match in 100 log lines', () => {
+  const input = {
+    api_key: SENSITIVE_STRING_VALUE,
+    logs: LOGS_WITH_MATCH,
+  };
+
+  bench('default', () => {
+    sanitizeData(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// String input variants (form-encoded, escaped JSON)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — form-encoded string input', () => {
+  bench('mask (default)', () => {
+    sanitizeData(FORM_ENCODED_STRING);
+  });
+  bench('remove', () => {
+    sanitizeData(FORM_ENCODED_STRING, { removeMatches: true });
+  });
+});
+
+describe('sanitizeData — escaped JSON string input', () => {
+  bench('mask (default)', () => {
+    sanitizeData(ESCAPED_JSON_STRING);
+  });
+  bench('remove', () => {
+    sanitizeData(ESCAPED_JSON_STRING, { removeMatches: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deeply nested, 5 levels × 10 non-sensitive string fields per level
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — deeply nested, many non-sensitive strings (5 × 10 fields)', () => {
+  bench('default', () => {
+    sanitizeData(DEEP_NESTED_MANY_SAFE);
+  });
+  bench('scanStringValues disabled', () => {
+    sanitizeData(DEEP_NESTED_MANY_SAFE, { scanStringValues: false });
   });
 });

--- a/bench/sanitize-data.bench.ts
+++ b/bench/sanitize-data.bench.ts
@@ -260,7 +260,7 @@ describe('sanitizeData — large flat object, 5 sensitive keys', () => {
 
 // ---------------------------------------------------------------------------
 // Array — simple items (3 fields: id, token, username; 1 sensitive key)
-// Sizes: 1k / 10k / 100k / 1M / 10M
+// Sizes: 1k / 10k / 100k / 1M
 // ---------------------------------------------------------------------------
 
 describe('sanitizeData — array, simple items (1 sensitive), 1,000 items', () => {

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,360 @@
+# Performance
+
+`sanitizeData` is designed for in-process sanitization of log payloads,
+request/response objects, and similar data before they leave your application.
+It is not designed for streaming pipelines or bulk batch processing of large
+files.
+
+All numbers below are rough throughput on a modern laptop (Apple M-series,
+Node.js 22). Run the suite yourself with `yarn bench`.
+
+## String-value scanning overhead
+
+String-value scanning (`scanStringValues: true`, the default) checks every
+non-sensitive string field for embedded patterns using a fast OR pre-filter
+before running the full regex suite. The pre-filter cost is low even when no
+pattern matches, but it is not zero — the overhead scales with the length and
+quantity of non-sensitive string values in the input.
+
+The chart below shows the throughput reduction from enabling scanning relative
+to disabling it, sorted from highest to lowest overhead:
+
+```mermaid
+xychart-beta
+    title "scanStringValues overhead by workload (sorted)"
+    x-axis ["Log stack hit", "10KB string", "Log embed", "Arr-of-strs", "Shallow", "Log stack miss", "Nested", "Flat 5-key", "Flat 1-key", "Arrays"]
+    y-axis "overhead pct" 0 --> 90
+    bar [80, 76, 70, 64, 55, 49, 44, 19, 15, 3]
+```
+
+Key observations:
+
+- **Log objects with long strings** pay the most — even a clean stack trace
+  with no matches incurs ~49% overhead because the pre-filter must scan a long
+  string. A matching stack trace hits ~80%.
+- **10KB non-sensitive string values** incur ~76% overhead — the pre-filter
+  must scan the full length even when it exits immediately with no match.
+- **Array-of-strings fields** (e.g. 100 log lines) pay ~64% — per-item
+  pre-filter cost accumulates across all array elements.
+- **Small shallow objects** pay ~44–55% overhead — visible but
+  sub-millisecond (~0.004–0.005 ms/call).
+- **Large flat objects** pay ~15–19% — scanning 45–49 non-sensitive fields
+  costs less per field than scanning fewer long fields.
+- **Arrays** pay only ~2–4% — the per-item pre-filter cost is negligible
+  compared to the work of traversing each item.
+
+## Array scaling
+
+Array throughput scales nearly linearly with item count. The chart below shows
+items processed per second (ops/s × items/call) across four sizes for simple
+items (3 fields, 1 sensitive key), with scan enabled and disabled:
+
+```mermaid
+xychart-beta
+    title "Array throughput items per second thousands"
+    x-axis ["1k items", "10k items", "100k items", "1M items"]
+    y-axis "items per sec thousands" 0 --> 2400
+    line [2043, 2054, 1733, 1742]
+    line [2123, 2128, 1771, 1812]
+```
+
+The two lines are scan enabled (lower) and scan disabled (upper). They are
+nearly indistinguishable — the ~4% gap is smaller than benchmark noise at this
+scale. The slight drop at 100k and 1M items reflects GC pressure from the
+large input array, not algorithmic degradation.
+
+## Object workload benchmarks
+
+Rough throughput on a modern laptop (Apple M-series, Node.js 22):
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Workload</th>
+      <th rowspan="2">Case</th>
+      <th colspan="2"><code>scanStringValues: true</code></th>
+      <th colspan="2"><code>scanStringValues: false</code></th>
+      <th rowspan="2">scan overhead</th>
+    </tr>
+    <tr>
+      <th>ops/s</th>
+      <th>ms/call</th>
+      <th>ops/s</th>
+      <th>ms/call</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">Shallow object (4 fields)</td>
+      <td>1 sensitive key</td>
+      <td>~243,000</td><td>~0.004</td>
+      <td>~545,000</td><td>~0.002</td>
+      <td>~55%</td>
+    </tr>
+    <tr>
+      <td>4 sensitive keys (all)</td>
+      <td>~253,000</td><td>~0.004</td>
+      <td>—</td><td>—</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>Deeply nested (5 levels)</td>
+      <td>multiple sensitive keys</td>
+      <td>~202,000</td><td>~0.005</td>
+      <td>~363,000</td><td>~0.003</td>
+      <td>~44%</td>
+    </tr>
+    <tr>
+      <td rowspan="3">Log object (5 fields)</td>
+      <td>embedded credential in string value</td>
+      <td>~107,000</td><td>~0.009</td>
+      <td>~360,000</td><td>~0.003</td>
+      <td>~70%</td>
+    </tr>
+    <tr>
+      <td>stack trace with embedded credentials</td>
+      <td>~79,000</td><td>~0.013</td>
+      <td>~388,000</td><td>~0.003</td>
+      <td>~80%</td>
+    </tr>
+    <tr>
+      <td>clean stack trace (pre-filter fast-exit)</td>
+      <td>~199,000</td><td>~0.005</td>
+      <td>~389,000</td><td>~0.003</td>
+      <td>~49%</td>
+    </tr>
+    <tr>
+      <td>Many embedded matches (21 fields)</td>
+      <td>20 string values all containing a pattern</td>
+      <td>~13,000</td><td>~0.077</td>
+      <td>—</td><td>—</td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Large flat object (50 fields)</td>
+      <td>1 sensitive key</td>
+      <td>~69,000</td><td>~0.015</td>
+      <td>~80,000</td><td>~0.012</td>
+      <td>~15%</td>
+    </tr>
+    <tr>
+      <td>5 sensitive keys</td>
+      <td>~69,000</td><td>~0.015</td>
+      <td>~86,000</td><td>~0.012</td>
+      <td>~19%</td>
+    </tr>
+    <tr>
+      <td rowspan="2">Object with 10KB string field</td>
+      <td>1 sensitive key + 10KB non-sensitive value</td>
+      <td>~143,000</td><td>~0.007</td>
+      <td>~596,000</td><td>~0.002</td>
+      <td>~76%</td>
+    </tr>
+    <tr>
+      <td>array-of-strings field (100 clean log lines)</td>
+      <td>~151,000</td><td>~0.007</td>
+      <td>~415,000</td><td>~0.002</td>
+      <td>~64%</td>
+    </tr>
+    <tr>
+      <td>Deeply nested (5 × 10 safe strings)</td>
+      <td>5 levels, 10 non-sensitive string fields each</td>
+      <td>~29,000</td><td>~0.035</td>
+      <td>~32,000</td><td>~0.031</td>
+      <td>~11%</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Array — simple items<br>(3 fields: 1 sensitive)</td>
+      <td>1,000 items</td>
+      <td>~2,043</td><td>~0.49</td>
+      <td>~2,123</td><td>~0.47</td>
+      <td>~4%</td>
+    </tr>
+    <tr>
+      <td>10,000 items</td>
+      <td>~205</td><td>~4.9</td>
+      <td>~213</td><td>~4.7</td>
+      <td>~4%</td>
+    </tr>
+    <tr>
+      <td>100,000 items</td>
+      <td>~17</td><td>~58</td>
+      <td>~18</td><td>~56</td>
+      <td>~2%</td>
+    </tr>
+    <tr>
+      <td>1,000,000 items</td>
+      <td>~1.7</td><td>~574</td>
+      <td>~1.8</td><td>~552</td>
+      <td>~4%</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Array — complex items<br>(10 fields: 5 sensitive)</td>
+      <td>1,000 items</td>
+      <td>~516</td><td>~1.94</td>
+      <td>~539</td><td>~1.86</td>
+      <td>~4%</td>
+    </tr>
+    <tr>
+      <td>10,000 items</td>
+      <td>~51</td><td>~19.5</td>
+      <td>~53</td><td>~18.9</td>
+      <td>~3%</td>
+    </tr>
+    <tr>
+      <td>100,000 items</td>
+      <td>~5.0</td><td>~201</td>
+      <td>~5.0</td><td>~201</td>
+      <td>~0%</td>
+    </tr>
+    <tr>
+      <td>1,000,000 items</td>
+      <td>~0.50</td><td>~2,015</td>
+      <td>~0.50</td><td>~1,982</td>
+      <td>~2%</td>
+    </tr>
+  </tbody>
+</table>
+
+The "Many embedded matches" case is the worst case: every scanned string value
+actually contains a pattern and runs the full regex suite.
+
+Set `scanStringValues: false` to recover the pre-scanning performance when you
+control your data structure and know sensitive values only appear on
+sensitive-named keys.
+
+## Cold start cost
+
+On first call with a given set of options, `sanitizeData` compiles and caches
+the regex set for that configuration. Subsequent calls with the same options
+reuse the cache and pay no compile cost.
+
+| Case                                 | ops/s    | ms/call |
+| ------------------------------------ | -------- | ------- |
+| Warm cache (same options each call)  | ~246,000 | ~0.004  |
+| Cold start (unique options per call) | ~14,000  | ~0.070  |
+
+The first call is ~17× slower than a warm call due to regex compilation.
+In steady-state server usage this cost is paid once per process lifetime and
+is negligible. It becomes visible only in tests or scripts that create many
+distinct option configurations (e.g. per-request custom patterns).
+
+See [Cache memory growth](#cache-memory-growth) below for the memory
+implication of many distinct configurations.
+
+## removeMatches overhead
+
+`removeMatches: true` deletes matched fields from objects and matched
+key=value pairs from strings instead of masking them. The cost is similar to
+masking for objects but slightly higher for string inputs due to regex
+replacement pattern differences.
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Workload</th>
+      <th colspan="2">mask (default)</th>
+      <th colspan="2">remove</th>
+      <th rowspan="2">remove overhead</th>
+    </tr>
+    <tr>
+      <th>ops/s</th>
+      <th>ms/call</th>
+      <th>ops/s</th>
+      <th>ms/call</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Shallow object (4 fields, 1 sensitive)</td>
+      <td>~234,000</td><td>~0.004</td>
+      <td>~234,000</td><td>~0.004</td>
+      <td>~0%</td>
+    </tr>
+    <tr>
+      <td>Large flat object (50 fields, 1 sensitive)</td>
+      <td>~68,000</td><td>~0.015</td>
+      <td>~61,000</td><td>~0.016</td>
+      <td>~11%</td>
+    </tr>
+    <tr>
+      <td>Array (1,000 items, 1 sensitive key)</td>
+      <td>~2,096</td><td>~0.48</td>
+      <td>~1,979</td><td>~0.51</td>
+      <td>~6%</td>
+    </tr>
+    <tr>
+      <td>Form-encoded string</td>
+      <td>~101,000</td><td>~0.010</td>
+      <td>~81,000</td><td>~0.012</td>
+      <td>~20%</td>
+    </tr>
+  </tbody>
+</table>
+
+For objects, removal and masking are nearly equivalent — both write a result
+object with the same traversal cost. For strings, removal is 10–20% slower
+because the match-and-remove regex path involves different replacement
+semantics than the `$1<mask>$2` substitution.
+
+## String workloads
+
+String input always scans the full string regardless of `scanStringValues`.
+The option only affects the object traversal path.
+
+| Workload                                        | ops/s    | ms/call | remove ops/s |
+| ----------------------------------------------- | -------- | ------- | ------------ |
+| Long JSON string (50 sensitive key/value pairs) | ~6,989   | ~0.143  | —            |
+| Form-encoded string (1 sensitive field)         | ~102,000 | ~0.010  | ~84,000      |
+| Escaped JSON string (1 sensitive field)         | ~91,000  | ~0.011  | ~69,000      |
+
+## High pattern counts
+
+Pattern count affects object workloads proportionally when
+`scanStringValues: true`. With default patterns disabled:
+
+| Workload                                               | ops/s   | ms/call |
+| ------------------------------------------------------ | ------- | ------- |
+| 50-field object, 50 custom patterns (no string match)  | ~22,000 | ~0.046  |
+| 3-field object, 50 custom patterns (no string match)   | ~55,000 | ~0.018  |
+| 3-field object, 50 custom patterns (string value hits) | ~18,000 | ~0.056  |
+
+## Production gotchas
+
+### Cache memory growth
+
+`sanitizeData` caches compiled regex sets in a module-level LRU `Map` keyed
+by the full option fingerprint (matchers + patterns + `removeMatches` flag).
+The cache holds at most **10 entries**; when full, the least-recently-used
+entry is evicted to make room for the new one.
+
+In steady-state usage — a fixed configuration, possibly with a static list of
+`customPatterns` — the cache stays at 1–3 entries and this is not a concern.
+
+If `customPatterns` vary per call (e.g. injected from user input or request
+data), entries will cycle through the cache and every call will pay the
+cold-start regex compilation cost (~17× slower than a warm call). In that
+scenario, prebuild the options object once (or a small set of them) and reuse
+it across calls. Or set `scanStringValues: false`, which bypasses the cache
+entirely.
+
+### Form-encoded matcher and multiline strings
+
+The built-in form-encoded matcher uses `[^\n&]*` to match a field value —
+stopping at either an `&` delimiter or a newline. This means content on lines
+after a matched value is preserved:
+
+```text
+Input:  "Error: auth failed — api_key=hunter2\n    at foo (bar.js:10)"
+Output: "Error: auth failed — api_key=**********\n    at foo (bar.js:10)"
+```
+
+Stack traces and other multiline fields are safe to scan.
+
+## Running the benchmarks
+
+```bash
+yarn bench
+```
+
+Benchmarks live in [`bench/sanitize-data.bench.ts`](../bench/sanitize-data.bench.ts).

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ const createSafeErrorDetails = (
  * then parsed back.
  *
  * @param data - String, null, or object data to be sanitized.
- * @param options - Matcher, pattern, masking, and removal options.
+ * @param options - Matcher, pattern, masking, removal, and string-scan options.
  * @returns Sanitized data in the original supported input type when possible.
  * @throws {DataSanitizationError} When the input data type cannot be sanitized.
  * @throws {DataSanitizationError} When sanitized object data cannot be parsed back to JSON.
@@ -81,6 +81,11 @@ const createSafeErrorDetails = (
  * // Sanitize with a custom mask
  * sanitizeData({ token: 'abc123' }, { patternMask: '[REDACTED]' })
  * // => { token: '[REDACTED]' }
+ *
+ * @example
+ * // String values on non-sensitive keys are scanned for embedded patterns by default
+ * sanitizeData({ message: 'request failed: api_key=hunter2' })
+ * // => { message: 'request failed: api_key=**********' }
  */
 const sanitizeData: DataSanitizationReplacer = (data, options = {}) => {
   try {

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -56,7 +56,7 @@ const formEncodedMatcher: DataSanitizationMatcher = (
   const escaped = escapePattern(pattern);
   const fieldName = `\\w*${escaped}\\w*`;
   const fieldPrefix = `${fieldName}[=:]`;
-  const fieldValue = '[^&]*';
+  const fieldValue = '[^\\n&]*';
 
   if (remove) {
     const removeLeadingField = `&${fieldPrefix}${fieldValue}`;
@@ -65,7 +65,9 @@ const formEncodedMatcher: DataSanitizationMatcher = (
     return new RegExp(`${removeLeadingField}|${removeField}`, MATCHER_FLAGS);
   }
 
-  const maskField = `(${fieldPrefix})${fieldValue}(&|$)`;
+  // Use a zero-width lookahead for \n so the newline is not consumed and
+  // content on subsequent lines is preserved in the output.
+  const maskField = `(${fieldPrefix})${fieldValue}(&|(?=\\n|$))`;
 
   return new RegExp(maskField, MATCHER_FLAGS);
 };

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -56,7 +56,7 @@ const formEncodedMatcher: DataSanitizationMatcher = (
   const escaped = escapePattern(pattern);
   const fieldName = `\\w*${escaped}\\w*`;
   const fieldPrefix = `${fieldName}[=:]`;
-  const fieldValue = '[^\\n&]*';
+  const fieldValue = '[^\\r\\n&]*';
 
   if (remove) {
     const removeLeadingField = `&${fieldPrefix}${fieldValue}`;
@@ -65,9 +65,9 @@ const formEncodedMatcher: DataSanitizationMatcher = (
     return new RegExp(`${removeLeadingField}|${removeField}`, MATCHER_FLAGS);
   }
 
-  // Use a zero-width lookahead for \n so the newline is not consumed and
-  // content on subsequent lines is preserved in the output.
-  const maskField = `(${fieldPrefix})${fieldValue}(&|(?=\\n|$))`;
+  // Zero-width lookahead so neither \r nor \n is consumed; content on
+  // subsequent lines is preserved in the output.
+  const maskField = `(${fieldPrefix})${fieldValue}(&|(?=\\r?\\n|$))`;
 
   return new RegExp(maskField, MATCHER_FLAGS);
 };

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -22,6 +22,44 @@ const buildMatchers = (
   return Array.isArray(customMatchers) ? [...base, ...customMatchers] : base;
 };
 
+interface StringScanRegexes {
+  preFilter: RegExp | null;
+  regexes: RegExp[];
+}
+
+const stringScanCache = new Map<string, StringScanRegexes>();
+
+const buildStringScanRegexes = (
+  matchers: DataSanitizationMatcher[],
+  patterns: string[],
+  removeMatches: boolean,
+): StringScanRegexes => {
+  const key =
+    matchers.map((m) => m.toString()).join('\x00') +
+    '\x01' +
+    patterns.join('\x00') +
+    '\x01' +
+    removeMatches;
+
+  const cached = stringScanCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const result: StringScanRegexes = {
+    preFilter:
+      patterns.length > 0
+        ? new RegExp(patterns.map(escapePattern).join('|'), 'i')
+        : null,
+    regexes: patterns.flatMap((pattern) =>
+      matchers.map((matcher) => matcher(pattern, removeMatches)),
+    ),
+  };
+
+  stringScanCache.set(key, result);
+  return result;
+};
+
 /**
  * Sanitizes a string by masking or removing sensitive data.
  *
@@ -80,9 +118,11 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
 
 /**
  * Sanitizes object fields by key name, masking or removing matched keys.
+ * String values on non-sensitive keys are scanned for embedded sensitive
+ * patterns using the configured matchers and masked or removed in place.
  *
  * @param data - Object or array data to sanitize.
- * @param options - Pattern, masking, and removal options.
+ * @param options - Pattern, matcher, masking, removal, and string-scan options.
  * @returns Sanitized object/array data, or the original non-object data for runtime safety.
  * @throws {TypeError} If a circular reference is encountered.
  *
@@ -91,15 +131,22 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
  * // => { password: '**********', username: 'mark' }
  *
  * @example
+ * objectReplacer({ message: 'api_key=hunter2', username: 'mark' })
+ * // => { message: 'api_key=**********', username: 'mark' }
+ *
+ * @example
  * objectReplacer({ token: 123, username: 'mark' }, { removeMatches: true })
  * // => { username: 'mark' }
  */
 const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const {
+    customMatchers,
     customPatterns,
     numericMask,
     patternMask,
     removeMatches = false,
+    scanStringValues = true,
+    useDefaultMatchers = true,
     useDefaultPatterns = true,
   } = options;
 
@@ -108,13 +155,35 @@ const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
   }
 
   const mask = patternMask ?? DEFAULT_PATTERN_MASK;
+  const matchers = buildMatchers(useDefaultMatchers, customMatchers);
   const patterns = buildPatterns(useDefaultPatterns, customPatterns);
   const keyMatchers = patterns.map(
     (pattern) => new RegExp(`\\w*${escapePattern(pattern)}\\w*`, 'i'),
   );
+  const { preFilter: patternPreFilter, regexes: stringRegexes } =
+    scanStringValues
+      ? buildStringScanRegexes(matchers, patterns, removeMatches)
+      : { preFilter: null, regexes: [] };
   const seen = new WeakSet<object>();
 
+  const scanStringValue = (value: string): string => {
+    if (!patternPreFilter?.test(value)) {
+      return value;
+    }
+    let result = value;
+    for (const regex of stringRegexes) {
+      result = removeMatches
+        ? result.replace(regex, '')
+        : result.replace(regex, '$1' + mask + '$2');
+    }
+    return result;
+  };
+
   const sanitizeValue = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return scanStringValue(value);
+    }
+
     if (typeof value !== 'object' || value === null) {
       return value;
     }

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -27,6 +27,7 @@ interface StringScanRegexes {
   regexes: RegExp[];
 }
 
+const STRING_SCAN_CACHE_MAX = 10;
 const stringScanCache = new Map<string, StringScanRegexes>();
 
 const buildStringScanRegexes = (
@@ -43,6 +44,9 @@ const buildStringScanRegexes = (
 
   const cached = stringScanCache.get(key);
   if (cached) {
+    // Refresh insertion order so this entry is treated as most recently used.
+    stringScanCache.delete(key);
+    stringScanCache.set(key, cached);
     return cached;
   }
 
@@ -56,6 +60,10 @@ const buildStringScanRegexes = (
     ),
   };
 
+  if (stringScanCache.size >= STRING_SCAN_CACHE_MAX) {
+    const [lruKey] = stringScanCache.keys();
+    stringScanCache.delete(lruKey);
+  }
   stringScanCache.set(key, result);
   return result;
 };

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -30,13 +30,28 @@ interface StringScanRegexes {
 const STRING_SCAN_CACHE_MAX = 10;
 const stringScanCache = new Map<string, StringScanRegexes>();
 
+// Assign stable numeric IDs to matcher functions by object identity so that
+// two closures with identical source but different captured state don't collide.
+const matcherIds = new WeakMap<DataSanitizationMatcher, number>();
+let matcherIdCounter = 0;
+
+const getMatcherId = (matcher: DataSanitizationMatcher): string => {
+  const existing = matcherIds.get(matcher);
+  if (existing !== undefined) {
+    return String(existing);
+  }
+  const id = matcherIdCounter++;
+  matcherIds.set(matcher, id);
+  return String(id);
+};
+
 const buildStringScanRegexes = (
   matchers: DataSanitizationMatcher[],
   patterns: string[],
   removeMatches: boolean,
 ): StringScanRegexes => {
   const key =
-    matchers.map((m) => m.toString()).join('\x00') +
+    matchers.map(getMatcherId).join('\x00') +
     '\x01' +
     patterns.join('\x00') +
     '\x01' +

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,12 @@ interface DataSanitizationReplacerOptions {
    */
   removeMatches?: boolean;
   /**
+   * Whether to scan string values on non-sensitive-key fields for embedded
+   * sensitive patterns. Disabling this improves performance on object
+   * workloads. Has no effect on string input. Default: true
+   */
+  scanStringValues?: boolean;
+  /**
    * Whether to use the built-in default matchers. Default: true
    */
   useDefaultMatchers?: boolean;

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -196,6 +196,36 @@ describe('DataSanitizationMatchers', () => {
       // Assert
       expect(result).toBe('\n    at authenticate (/app/src/auth.js:89:15)');
     });
+
+    it('should stop matching at a CRLF line ending without consuming the CR', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('api_key');
+      const testData =
+        'api_key=hunter2\r\n    at authenticate (/app/src/auth.js:89:15)';
+
+      // Act
+      const allMatches = [...testData.matchAll(matcher)];
+
+      // Assert
+      expect(allMatches.length).toBe(1);
+      expect(allMatches[0]?.[0]).toEqual('api_key=hunter2');
+    });
+
+    it('should mask a field value and preserve CRLF lines that follow it', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('api_key');
+      const testData =
+        'api_key=hunter2\r\n    at authenticate (/app/src/auth.js:89:15)';
+      const mask = '**********';
+
+      // Act
+      const result = testData.replace(matcher, '$1' + mask + '$2');
+
+      // Assert
+      expect(result).toBe(
+        'api_key=**********\r\n    at authenticate (/app/src/auth.js:89:15)',
+      );
+    });
   });
 
   describe('jsonMatcher', () => {

--- a/test/matchers.test.ts
+++ b/test/matchers.test.ts
@@ -136,6 +136,66 @@ describe('DataSanitizationMatchers', () => {
       // Assert
       expect(result).toBe('username=mark');
     });
+
+    it('should stop matching at a newline in a multiline string', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('api_key');
+      const testData =
+        'api_key=hunter2\n    at authenticate (/app/src/auth.js:89:15)';
+
+      // Act
+      const allMatches = [...testData.matchAll(matcher)];
+
+      // Assert
+      expect(allMatches.length).toBe(1);
+      expect(allMatches[0]?.[1]).toEqual('api_key=');
+      expect(allMatches[0]?.[0]).toEqual('api_key=hunter2');
+    });
+
+    it('should mask a field value and preserve lines that follow it', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('api_key');
+      const testData =
+        'api_key=hunter2\n    at authenticate (/app/src/auth.js:89:15)';
+      const mask = '**********';
+
+      // Act
+      const result = testData.replace(matcher, '$1' + mask + '$2');
+
+      // Assert
+      expect(result).toBe(
+        'api_key=**********\n    at authenticate (/app/src/auth.js:89:15)',
+      );
+    });
+
+    it('should mask a field value when & follows on the same line and preserve subsequent lines', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('api_key');
+      const testData =
+        'api_key=hunter2&region=us-east-1\n    at authenticate (/app/src/auth.js:89:15)';
+      const mask = '**********';
+
+      // Act
+      const result = testData.replace(matcher, '$1' + mask + '$2');
+
+      // Assert
+      expect(result).toBe(
+        'api_key=**********&region=us-east-1\n    at authenticate (/app/src/auth.js:89:15)',
+      );
+    });
+
+    it('should produce a removal regex that stops at newlines and preserves subsequent lines', () => {
+      // Arrange
+      const matcher = formEncodedMatcher('api_key', true);
+      const testData =
+        'api_key=hunter2\n    at authenticate (/app/src/auth.js:89:15)';
+
+      // Act
+      const result = testData.replace(matcher, '');
+
+      // Assert
+      expect(result).toBe('\n    at authenticate (/app/src/auth.js:89:15)');
+    });
   });
 
   describe('jsonMatcher', () => {

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -5,6 +5,12 @@ import { describe, expect, it } from 'vitest';
 import { objectReplacer, stringReplacer } from '../src/replacers';
 import { DEFAULT_NUMERIC_MASK, DEFAULT_PATTERN_MASK } from '../src/constants';
 
+const headerMatcher = (pattern: string) =>
+  new RegExp(
+    `(${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:\\s*).+?(\\n|$)`,
+    'gi',
+  );
+
 describe('DataSanitizationReplacers', () => {
   describe('stringReplacer', () => {
     describe('masking', () => {
@@ -623,6 +629,148 @@ describe('DataSanitizationReplacers', () => {
         // Assert
         expect(result).toEqual({ username: 'mark' });
         expect(Object.getOwnPropertySymbols(result)).toHaveLength(0);
+      });
+    });
+
+    describe('string-value scanning', () => {
+      it('should scan string values on non-sensitive keys for embedded patterns', () => {
+        // Arrange
+        const testData = {
+          message: 'api_key=hunter2',
+          username: 'mark',
+        };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect(result.message).toEqual(`api_key=${DEFAULT_PATTERN_MASK}`);
+        expect(result.username).toEqual('mark');
+      });
+
+      it('should scan string values at any nesting depth', () => {
+        // Arrange
+        const testData = {
+          config: {
+            log: 'connection failed: token=abc123',
+            status: 'ok',
+          },
+        };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect((result.config as Record<string, unknown>).log).toEqual(
+          `connection failed: token=${DEFAULT_PATTERN_MASK}`,
+        );
+        expect((result.config as Record<string, unknown>).status).toEqual('ok');
+      });
+
+      it('should scan string items inside arrays under non-sensitive keys', () => {
+        // Arrange
+        const testData = {
+          logs: ['api_key=hunter2', 'safe-message'],
+        };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect(result.logs).toEqual([
+          `api_key=${DEFAULT_PATTERN_MASK}`,
+          'safe-message',
+        ]);
+      });
+
+      it('should remove embedded patterns in string values when removeMatches is true', () => {
+        // Arrange
+        const testData = {
+          message: 'api_key=hunter2&username=mark',
+          region: 'us-east-1',
+        };
+
+        // Act
+        const result = objectReplacer(testData, {
+          removeMatches: true,
+        }) as Record<string, unknown>;
+
+        // Assert
+        expect(result.message).toEqual('username=mark');
+        expect(result.region).toEqual('us-east-1');
+      });
+
+      it('should scan string values using custom matchers', () => {
+        // Arrange
+        const testData = {
+          authorization: 'Bearer abc123',
+          log: 'authorization: Bearer abc123\nuser: mark',
+        };
+
+        // Act
+        const result = objectReplacer(testData, {
+          customMatchers: [headerMatcher],
+          customPatterns: ['authorization'],
+          useDefaultMatchers: false,
+          useDefaultPatterns: false,
+        }) as Record<string, unknown>;
+
+        // Assert
+        expect(result.authorization).toEqual(DEFAULT_PATTERN_MASK);
+        expect(result.log).toEqual(
+          `authorization: ${DEFAULT_PATTERN_MASK}\nuser: mark`,
+        );
+      });
+
+      it('should leave string values unchanged when no patterns match', () => {
+        // Arrange
+        const testData = {
+          message: 'everything looks fine',
+          region: 'us-east-1',
+        };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect(result.message).toEqual('everything looks fine');
+        expect(result.region).toEqual('us-east-1');
+      });
+
+      it('should leave string values unchanged when no patterns are configured', () => {
+        // Arrange
+        const testData = {
+          message: 'api_key=hunter2',
+          username: 'mark',
+        };
+
+        // Act
+        const result = objectReplacer(testData, {
+          useDefaultPatterns: false,
+        }) as Record<string, unknown>;
+
+        // Assert
+        expect(result.message).toEqual('api_key=hunter2');
+        expect(result.username).toEqual('mark');
+      });
+
+      it('should not scan string values when scanStringValues is false', () => {
+        // Arrange
+        const testData = {
+          message: 'api_key=hunter2',
+          password: 'secret',
+          username: 'mark',
+        };
+
+        // Act
+        const result = objectReplacer(testData, {
+          scanStringValues: false,
+        }) as Record<string, unknown>;
+
+        // Assert
+        expect(result.message).toEqual('api_key=hunter2');
+        expect(result.password).toEqual(DEFAULT_PATTERN_MASK);
+        expect(result.username).toEqual('mark');
       });
     });
   });

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -792,6 +792,42 @@ describe('DataSanitizationReplacers', () => {
         expect(result.username).toEqual('mark');
       });
 
+      it('should treat two closures with identical source but different captured state as distinct cache entries', () => {
+        // Arrange — same factory produces closures with identical source text but
+        // different captured prefix; toString()-based keys would collide and use
+        // the first closure's regexes for all subsequent calls with identical source
+        const makeCustomMatcher =
+          (prefix: string) =>
+          (pattern: string): RegExp =>
+            // Group 1: prefix+key+delimiter, Group 2: trailing & or end-of-string
+            new RegExp(`(${prefix}${pattern}=)[^&\\n]+(&|$)`, 'gi');
+
+        const matcherA = makeCustomMatcher('a_');
+        const matcherB = makeCustomMatcher('b_');
+
+        const testData = { log: 'a_key=AVALUE&b_key=BVALUE', username: 'mark' };
+        const sharedOptions = {
+          customPatterns: ['key'],
+          useDefaultMatchers: false,
+          useDefaultPatterns: false,
+        };
+
+        // Act — prime the cache with matcherA, then apply matcherB
+        objectReplacer(testData, {
+          ...sharedOptions,
+          customMatchers: [matcherA],
+        });
+        const result = objectReplacer(testData, {
+          ...sharedOptions,
+          customMatchers: [matcherB],
+        }) as Record<string, unknown>;
+
+        // Assert — matcherB should mask b_key only; a cache collision would
+        // return matcherA's regexes and mask a_key instead
+        expect(result.log).toContain(`b_key=${DEFAULT_PATTERN_MASK}`);
+        expect(result.log).toContain('a_key=AVALUE');
+      });
+
       it('should return correct results after string-scan cache eviction', () => {
         // Arrange — fill the cache past the 10-entry cap with distinct configs
         const testData = {

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -754,6 +754,25 @@ describe('DataSanitizationReplacers', () => {
         expect(result.username).toEqual('mark');
       });
 
+      it('should mask embedded sensitive patterns in a stack trace string and preserve stack frames', () => {
+        // Arrange
+        const testData = {
+          requestId: 'req-abc-123',
+          stack: `Error: upstream request failed — api_key=hunter2\n    at authenticate (/app/src/auth.js:89:15)\n    at processRequest (/app/src/handlers.js:134:20)`,
+          userId: 'usr-456',
+        };
+
+        // Act
+        const result = objectReplacer(testData) as Record<string, unknown>;
+
+        // Assert
+        expect(result.stack).toEqual(
+          `Error: upstream request failed — api_key=${DEFAULT_PATTERN_MASK}\n    at authenticate (/app/src/auth.js:89:15)\n    at processRequest (/app/src/handlers.js:134:20)`,
+        );
+        expect(result.requestId).toEqual('req-abc-123');
+        expect(result.userId).toEqual('usr-456');
+      });
+
       it('should not scan string values when scanStringValues is false', () => {
         // Arrange
         const testData = {
@@ -770,6 +789,32 @@ describe('DataSanitizationReplacers', () => {
         // Assert
         expect(result.message).toEqual('api_key=hunter2');
         expect(result.password).toEqual(DEFAULT_PATTERN_MASK);
+        expect(result.username).toEqual('mark');
+      });
+
+      it('should return correct results after string-scan cache eviction', () => {
+        // Arrange — fill the cache past the 10-entry cap with distinct configs
+        const testData = {
+          log: 'custom_0=secret&other=safe',
+          username: 'mark',
+        };
+        for (let i = 0; i < 11; i++) {
+          objectReplacer(testData, {
+            customPatterns: [`custom_${i}`],
+            useDefaultPatterns: false,
+          });
+        }
+
+        // Act — re-use the first config, which was evicted; must still work
+        const result = objectReplacer(testData, {
+          customPatterns: ['custom_0'],
+          useDefaultPatterns: false,
+        }) as Record<string, unknown>;
+
+        // Assert
+        expect(result.log).toEqual(
+          `custom_0=${DEFAULT_PATTERN_MASK}&other=safe`,
+        );
         expect(result.username).toEqual('mark');
       });
     });


### PR DESCRIPTION
## Summary

- Adds string-value scanning to `objectReplacer`: string values on non-sensitive-key fields are now scanned for embedded sensitive patterns by default (e.g. `{ message: 'api_key=hunter2' }` → `{ message: 'api_key=**********' }`)
- Adds `scanStringValues` option (default `true`) to opt out and recover pre-feature performance
- Uses a module-level regex cache and OR pre-filter to minimise per-call cost — first call with a given config pays construction; all subsequent calls are near-free
- Expands benchmark suite from 4 to 14 cases, including `scanStringValues: true/false` paired comparisons, many-embedded-matches worst case, and wide-object + high-pattern-count cases
- Updates README Performance section with full before/after throughput tables and documents the `scanStringValues` tradeoff

## Performance impact (Apple M-series, Node.js 22)

| Workload | `scanStringValues: true` | `scanStringValues: false` |
| --- | --- | --- |
| Shallow object (4 fields) | ~249,000 ops/s | ~558,000 ops/s |
| Deeply nested (5 levels) | ~208,000 ops/s | ~389,000 ops/s |
| Object with embedded credential | ~106,000 ops/s | ~399,000 ops/s |
| Many embedded matches (20 fields) | ~13,000 ops/s | — |
| Large flat object (50 fields) | ~72,000 ops/s | ~91,000 ops/s |
| Large array (1,000 items) | ~2,200 ops/s | ~2,400 ops/s |

## Test plan

- [ ] `yarn test` — 93 tests passing
- [ ] `yarn lint` — clean
- [ ] `yarn format:check` — clean
- [ ] `yarn build` — clean
- [ ] `yarn bench` — all 14 benchmark cases run and print results
- [ ] Verify `scanStringValues: false` restores pre-feature key-masking behaviour without value scanning
- [ ] Verify embedded credential in string value is masked by default

## Checklist

- [x] New option documented in README Options table and TSDoc
- [x] Performance section updated with full before/after tables
- [x] `scanStringValues` has no effect on string input (documented in TSDoc and README)
- [x] Module-level cache keyed on matchers + patterns + removeMatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scanStringValues option (default: true) to scan and sanitize embedded sensitive patterns inside string values on non-sensitive object keys; can be disabled to recover pre-scan object performance.

* **Documentation**
  * Added Performance section with benchmark comparisons, guidance, and bench invocation; clarified object vs string input behaviour and string-scan overhead.

* **Bug Fixes**
  * Fixed form-encoded masking to preserve newlines and subsequent content.

* **Tests**
  * Added unit and extensive benchmark tests covering string-value scanning, removal, custom matchers, nesting, arrays and cache-eviction scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->