### PR TITLE
feat: parser-first JSON string handling (parseJsonStrings option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ sanitizeData('{"password":12345,"username":"mark"}', {
 ```
 
 Note: the result is re-serialized with `JSON.stringify`, which does not preserve
-original whitespace or indentation.
+original whitespace or indentation. Enable this option when formatting fidelity
+is not required — it is faster and more correct than the default regex path.
 
 ### Remove fields instead of masking
 
@@ -195,25 +196,25 @@ masking them.
 ```typescript
 sanitizeData(patient, {
   customPatterns: sensitivePatterns,
-  useDefaultPatterns: false,
   removeMatches: true,
+  useDefaultPatterns: false,
 });
 // => { accountId: 'acct_123' }
 ```
 
 ## Options
 
-| Option               | Type                        | Default      | Description                                                                                                                                                                    |
-| -------------------- | --------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values                                                                                                                             |
-| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values                                                                                                                             |
-| `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking                                                                                                                              |
-| `scanStringValues`   | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns (object input only)                                                                                             |
-| `parseJsonStrings`   | `boolean`                   | `false`      | Parse string input as JSON and sanitize via the object path when valid. Note: re-serializes with `JSON.stringify`, which does not preserve original whitespace or indentation. |
-| `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match                                                                                                                                        |
-| `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                                                                                                            |
-| `useDefaultPatterns` | `boolean`                   | `true`       | Whether to include the built-in default patterns                                                                                                                               |
-| `useDefaultMatchers` | `boolean`                   | `true`       | Whether to include the built-in default matchers                                                                                                                               |
+| Option               | Type                        | Default      | Description                                                                                                                                                                        |
+| -------------------- | --------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values                                                                                                                                 |
+| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values                                                                                                                                 |
+| `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking                                                                                                                                  |
+| `scanStringValues`   | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns. Applies to object input and to string input when `parseJsonStrings` is enabled; has no effect on raw string input. |
+| `parseJsonStrings`   | `boolean`                   | `false`      | Parse valid JSON strings via the object path. Recommended unless formatting fidelity is required; re-serializes with `JSON.stringify`, discarding original whitespace.             |
+| `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match                                                                                                                                            |
+| `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                                                                                                                |
+| `useDefaultPatterns` | `boolean`                   | `true`       | Whether to include the built-in default patterns                                                                                                                                   |
+| `useDefaultMatchers` | `boolean`                   | `true`       | Whether to include the built-in default matchers                                                                                                                                   |
 
 ## Default patterns
 
@@ -286,8 +287,8 @@ const headerMatcher = (pattern: string) =>
   new RegExp(`(${pattern}:\\s*).+?(\\n|$)`, 'gi');
 
 sanitizeData('authorization: Bearer abc123\nuser: mark', {
-  customPatterns: ['authorization'],
   customMatchers: [headerMatcher],
+  customPatterns: ['authorization'],
   useDefaultMatchers: false,
 });
 // => 'authorization: **********\nuser: mark'
@@ -360,11 +361,48 @@ pre-filter cost is negligible. The cost is most visible on individual objects
 with long non-sensitive string values such as stack traces or large text
 fields; a single 10KB non-sensitive string value incurs ~76% overhead.
 
-Set `scanStringValues: false` to recover the pre-scanning performance when
-you control your data structure and know sensitive values only appear on
-sensitive-named keys.
+**`scanStringValues: false`** — Disables string-value scanning on the object
+path. Use this when you control your data structure and know sensitive values
+only appear on sensitive-named keys. Recovers the full pre-scanning throughput.
 
-For full benchmark tables, charts, and scaling analysis see
+**`parseJsonStrings: true`** — When your string inputs are JSON, this routes
+them through the object path instead of regex: 3–4× faster and correctly masks
+numeric-valued sensitive fields that the regex path cannot detect. The tradeoff
+is that the result is re-serialized with `JSON.stringify`, which does not
+preserve original whitespace or indentation.
+
+On first call with a given set of options, `sanitizeData` compiles its regex
+set and caches the result by option fingerprint. Subsequent calls with the same
+options reuse the cache at no extra cost — this applies whether options are
+passed inline or as a variable, as long as the content is the same.
+
+The one pattern to avoid is building `customPatterns` dynamically per call from
+variable data, such as from a request or database record:
+
+```typescript
+// Anti-pattern: patterns differ on every call — cache never hits
+app.post('/log', (req) => {
+  sanitizeData(req.body, {
+    customPatterns: [...basePatterns, ...req.user.sensitiveFields],
+  });
+});
+
+// Correct: build options once at startup (or per stable configuration)
+const sanitizerOptions = {
+  customPatterns: [...basePatterns, ...knownSensitiveFields],
+};
+
+app.post('/log', (req) => {
+  sanitizeData(req.body, sanitizerOptions);
+});
+```
+
+If dynamic options are unavoidable, set `scanStringValues: false` — this skips
+the string-scanning cache and avoids the fingerprinting overhead on every call.
+
+When options must genuinely vary per call, each call pays the first-call
+compilation cost (~17× slower than a cached call). For full benchmark tables,
+charts, and scaling analysis see
 [docs/performance.md](docs/performance.md). To run the suite:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ sanitizeData('password=secret&username=mark');
 // => 'password=**********&username=mark'
 ```
 
+### Parse JSON strings
+
+When a string input is valid JSON containing an object or array, set
+`parseJsonStrings: true` to sanitize it via the object path. This also correctly
+masks numeric-valued sensitive fields, which the default regex path cannot do:
+
+```typescript
+sanitizeData('{"password":12345,"username":"mark"}', {
+  parseJsonStrings: true,
+});
+// => '{"password":9999999999,"username":"mark"}'
+```
+
+Note: the result is re-serialized with `JSON.stringify`, which does not preserve
+original whitespace or indentation.
+
 ### Remove fields instead of masking
 
 ```typescript
@@ -186,16 +202,17 @@ sanitizeData(patient, {
 
 ## Options
 
-| Option               | Type                        | Default      | Description                                                                        |
-| -------------------- | --------------------------- | ------------ | ---------------------------------------------------------------------------------- |
-| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values                                 |
-| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values                                 |
-| `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking                                  |
-| `scanStringValues`   | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns (object input only) |
-| `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match                                            |
-| `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                |
-| `useDefaultPatterns` | `boolean`                   | `true`       | Whether to include the built-in default patterns                                   |
-| `useDefaultMatchers` | `boolean`                   | `true`       | Whether to include the built-in default matchers                                   |
+| Option               | Type                        | Default      | Description                                                                                                                                                                    |
+| -------------------- | --------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `patternMask`        | `string`                    | `**********` | String used to replace matched string field values                                                                                                                             |
+| `numericMask`        | `number`                    | `9999999999` | Number used to replace matched number field values                                                                                                                             |
+| `removeMatches`      | `boolean`                   | `false`      | Remove matched fields entirely instead of masking                                                                                                                              |
+| `scanStringValues`   | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns (object input only)                                                                                             |
+| `parseJsonStrings`   | `boolean`                   | `false`      | Parse string input as JSON and sanitize via the object path when valid. Note: re-serializes with `JSON.stringify`, which does not preserve original whitespace or indentation. |
+| `customPatterns`     | `string[]`                  | `[]`         | Additional field name patterns to match                                                                                                                                        |
+| `customMatchers`     | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                                                                                                            |
+| `useDefaultPatterns` | `boolean`                   | `true`       | Whether to include the built-in default patterns                                                                                                                               |
+| `useDefaultMatchers` | `boolean`                   | `true`       | Whether to include the built-in default matchers                                                                                                                               |
 
 ## Default patterns
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ dependencies.
   - [Usage](#usage)
     - [Quick start](#quick-start)
     - [Sanitize a string](#sanitize-a-string)
+    - [Parse JSON strings](#parse-json-strings)
     - [Remove fields instead of masking](#remove-fields-instead-of-masking)
     - [Sanitize PII and PHI with custom patterns](#sanitize-pii-and-phi-with-custom-patterns)
   - [Options](#options)

--- a/bench/sanitize-data.bench.ts
+++ b/bench/sanitize-data.bench.ts
@@ -636,3 +636,44 @@ describe('sanitizeData — deeply nested, many non-sensitive strings (5 × 10 fi
     sanitizeData(DEEP_NESTED_MANY_SAFE, { scanStringValues: false });
   });
 });
+
+// ---------------------------------------------------------------------------
+// parseJsonStrings: true vs false — string input containing JSON
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — JSON string, small (parseJsonStrings)', () => {
+  const input = JSON.stringify({
+    api_key: SENSITIVE_STRING_VALUE,
+    email: 'user@example.com',
+    region: 'us-east-1',
+    requestId: 'req-abc-123',
+    username: 'mark',
+  });
+
+  bench('parseJsonStrings disabled', () => {
+    sanitizeData(input);
+  });
+  bench('parseJsonStrings enabled', () => {
+    sanitizeData(input, { parseJsonStrings: true });
+  });
+});
+
+describe('sanitizeData — JSON string, large (parseJsonStrings)', () => {
+  const input = JSON.stringify(
+    Object.fromEntries([
+      ...Array.from({ length: 40 }, (_, i) => [`field_${i}`, `value ${i}`]),
+      ...Array.from({ length: 5 }, (_, i) => [
+        `secret_${i}`,
+        SENSITIVE_STRING_VALUE,
+      ]),
+      ...Array.from({ length: 5 }, (_, i) => [`token_${i}`, i * 1000]),
+    ]),
+  );
+
+  bench('parseJsonStrings disabled', () => {
+    sanitizeData(input);
+  });
+  bench('parseJsonStrings enabled', () => {
+    sanitizeData(input, { parseJsonStrings: true });
+  });
+});

--- a/bench/sanitize-data.bench.ts
+++ b/bench/sanitize-data.bench.ts
@@ -315,10 +315,10 @@ describe('sanitizeData — array, simple items (1 sensitive), 1,000,000 items', 
     username: `user-${i}`,
   }));
 
-  bench('default', () => {
+  bench.skip('default', () => {
     sanitizeData(input);
   });
-  bench('scanStringValues disabled', () => {
+  bench.skip('scanStringValues disabled', () => {
     sanitizeData(input, { scanStringValues: false });
   });
 });
@@ -412,10 +412,10 @@ describe('sanitizeData — array, complex items (5 sensitive), 1,000,000 items',
     ]),
   );
 
-  bench('default', () => {
+  bench.skip('default', () => {
     sanitizeData(input);
   });
-  bench('scanStringValues disabled', () => {
+  bench.skip('scanStringValues disabled', () => {
     sanitizeData(input, { scanStringValues: false });
   });
 });
@@ -675,5 +675,45 @@ describe('sanitizeData — JSON string, large (parseJsonStrings)', () => {
   });
   bench('parseJsonStrings enabled', () => {
     sanitizeData(input, { parseJsonStrings: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Option interaction: parseJsonStrings × scanStringValues
+// Representative log payload: 15 fields, 6 sensitive keys, 1 embedded
+// credential in a non-sensitive field, 1 stack trace, 7 safe fields.
+// ---------------------------------------------------------------------------
+
+describe('sanitizeData — option interaction (parseJsonStrings × scanStringValues)', () => {
+  const input = JSON.stringify({
+    api_key: SENSITIVE_STRING_VALUE,
+    api_secret: SENSITIVE_STRING_VALUE,
+    auth_token: SENSITIVE_STRING_VALUE,
+    environment: 'production',
+    message: `request failed: api_key=${SENSITIVE_STRING_VALUE}`,
+    method: 'POST',
+    password: SENSITIVE_STRING_VALUE,
+    path: '/api/v1/users',
+    region: 'us-east-1',
+    requestId: 'req-abc-123',
+    secret: SENSITIVE_STRING_VALUE,
+    service: 'api-gateway',
+    stack:
+      'Error: Connection refused\n    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1148:16)\n    at Object.onceWrapper (events.js:422:26)\n    at TCPConnectWrap.emit (events.js:400:28)',
+    token: SENSITIVE_STRING_VALUE,
+    username: 'mark',
+  });
+
+  bench('parseJsonStrings off, scanStringValues on (default)', () => {
+    sanitizeData(input);
+  });
+  bench('parseJsonStrings off, scanStringValues off', () => {
+    sanitizeData(input, { scanStringValues: false });
+  });
+  bench('parseJsonStrings on, scanStringValues on', () => {
+    sanitizeData(input, { parseJsonStrings: true });
+  });
+  bench('parseJsonStrings on, scanStringValues off', () => {
+    sanitizeData(input, { parseJsonStrings: true, scanStringValues: false });
   });
 });

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -115,16 +115,28 @@ match the sensitive-key patterns.
       non-sensitive-key field.
 - [x] Run benchmarks before and after to document the per-object perf cost.
 
+### Parser-First JSON String Handling — completed in #301
+
+When `parseJsonStrings: true`, valid JSON object/array strings are parsed,
+sanitized via `objectReplacer`, and re-serialized. Falls back to regex for
+non-JSON or primitive strings. Fixes the gap where numeric-valued sensitive
+fields are invisible to the regex path.
+
+- [x] Add `parseJsonStrings?: boolean` to `DataSanitizationReplacerOptions`.
+- [x] Add parse-first branch in `stringReplacer` after the non-string guard.
+- [x] Add tests: numeric masking, string masking, nested objects, arrays,
+      `removeMatches`, custom `numericMask`, fallback paths, integration.
+- [x] Add benchmark groups for `parseJsonStrings` enabled vs disabled.
+- [x] Update TSDoc on `sanitizeData` with `parseJsonStrings` example.
+- [x] Update `docs/performance.md` with parser-first benchmark results.
+- [x] Update README with options table row and "Parse JSON strings" usage
+      subsection.
+
 ## Future v2 Candidates
 
 These ideas may change behavior or public contracts, so they should be explored
 separately from routine v1.x maintenance.
 
-- [ ] Add parser-first handling for valid JSON strings: parse, sanitize with the
-      object traversal path, and serialize back only when parsing succeeds. Keep
-      regex-based string matching as a fallback for non-JSON strings.
-- [ ] Consider making parser-first string handling opt-in before changing any
-      default behavior.
 - [ ] Decide whether to explicitly support Map, Set, Date, class instances, typed
       arrays, or other non-plain objects.
 - [ ] Collect real v1.x usage signals before planning breaking changes.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -318,12 +318,12 @@ full string. The key correctness advantage is that numeric-typed sensitive
 fields (e.g. `{"password":12345}`) are masked with `numericMask` — the default
 regex path cannot detect or replace bare numeric values in strings.
 
-| Group | Variant                     | ops/s    | mean     |
-| ----- | --------------------------- | -------- | -------- |
-| small | `parseJsonStrings` disabled | ~65,783  | ~15.2 µs |
-| small | `parseJsonStrings` enabled  | ~271,150 | ~3.7 µs  |
-| large | `parseJsonStrings` disabled | ~17,164  | ~58.3 µs |
-| large | `parseJsonStrings` enabled  | ~50,848  | ~19.7 µs |
+| Group | Variant                     | ops/s    | ms/call |
+| ----- | --------------------------- | -------- | ------- |
+| small | `parseJsonStrings` disabled | ~65,783  | ~0.0152 |
+| small | `parseJsonStrings` enabled  | ~271,150 | ~0.0037 |
+| large | `parseJsonStrings` disabled | ~17,164  | ~0.0583 |
+| large | `parseJsonStrings` enabled  | ~50,848  | ~0.0197 |
 
 The large input case also demonstrates the correctness benefit: with
 `parseJsonStrings` enabled, numeric `token_N` fields are correctly masked with

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -308,6 +308,27 @@ The option only affects the object traversal path.
 | Form-encoded string (1 sensitive field)         | ~102,000 | ~0.010  | ~84,000      |
 | Escaped JSON string (1 sensitive field)         | ~91,000  | ~0.011  | ~69,000      |
 
+## Parser-first JSON strings
+
+When `parseJsonStrings: true` is set, string inputs that are valid JSON objects
+or arrays are parsed and sanitized via the object path rather than the regex
+path. The parse-and-re-serialize overhead is offset by the fact that the object
+traversal is faster than running each pattern against every matcher across the
+full string. The key correctness advantage is that numeric-typed sensitive
+fields (e.g. `{"password":12345}`) are masked with `numericMask` — the default
+regex path cannot detect or replace bare numeric values in strings.
+
+| Group | Variant                     | ops/s    | mean     |
+| ----- | --------------------------- | -------- | -------- |
+| small | `parseJsonStrings` disabled | ~65,783  | ~15.2 µs |
+| small | `parseJsonStrings` enabled  | ~271,150 | ~3.7 µs  |
+| large | `parseJsonStrings` disabled | ~17,164  | ~58.3 µs |
+| large | `parseJsonStrings` enabled  | ~50,848  | ~19.7 µs |
+
+The large input case also demonstrates the correctness benefit: with
+`parseJsonStrings` enabled, numeric `token_N` fields are correctly masked with
+`numericMask`, whereas the default regex path leaves them unmasked.
+
 ## High pattern counts
 
 Pattern count affects object workloads proportionally when

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -318,16 +318,75 @@ full string. The key correctness advantage is that numeric-typed sensitive
 fields (e.g. `{"password":12345}`) are masked with `numericMask` — the default
 regex path cannot detect or replace bare numeric values in strings.
 
-| Group | Variant                     | ops/s    | ms/call |
-| ----- | --------------------------- | -------- | ------- |
-| small | `parseJsonStrings` disabled | ~65,783  | ~0.0152 |
-| small | `parseJsonStrings` enabled  | ~271,150 | ~0.0037 |
-| large | `parseJsonStrings` disabled | ~17,164  | ~0.0583 |
-| large | `parseJsonStrings` enabled  | ~50,848  | ~0.0197 |
+<table>
+  <thead>
+    <tr>
+      <th rowspan="2">Workload</th>
+      <th colspan="2"><code>parseJsonStrings: false</code> (default)</th>
+      <th colspan="2"><code>parseJsonStrings: true</code></th>
+      <th rowspan="2">speedup</th>
+    </tr>
+    <tr>
+      <th>ops/s</th>
+      <th>ms/call</th>
+      <th>ops/s</th>
+      <th>ms/call</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Small JSON string (5 fields, 1 sensitive)</td>
+      <td>~65,783</td><td>~0.0152</td>
+      <td>~271,150</td><td>~0.0037</td>
+      <td>~4.1×</td>
+    </tr>
+    <tr>
+      <td>Large JSON string (50 fields, 5 sensitive string + 5 sensitive numeric)</td>
+      <td>~17,164</td><td>~0.0583</td>
+      <td>~50,848</td><td>~0.0197</td>
+      <td>~3.0×</td>
+    </tr>
+  </tbody>
+</table>
 
 The large input case also demonstrates the correctness benefit: with
 `parseJsonStrings` enabled, numeric `token_N` fields are correctly masked with
 `numericMask`, whereas the default regex path leaves them unmasked.
+
+## parseJsonStrings and scanStringValues interaction
+
+Both options interact on JSON string input. `scanStringValues` has no effect
+when `parseJsonStrings` is disabled — string input goes through the regex path,
+which does not use `scanStringValues`. When `parseJsonStrings` is enabled, string
+input is parsed to an object first; `scanStringValues` then applies normally on
+the object path.
+
+The chart below uses a representative 15-field log payload: 6 sensitive-named
+fields, 1 field with an embedded credential in a non-sensitive key, 1 stack
+trace, and 7 safe fields. The upper line is `scanStringValues: false`; the lower
+line is `scanStringValues: true`.
+
+```mermaid
+xychart-beta
+    title "parseJsonStrings x scanStringValues interaction (15-field log payload, ops/s)"
+    x-axis ["parseJsonStrings off", "parseJsonStrings on"]
+    y-axis "ops/s" 0 --> 200000
+    line [41000, 92000]
+    line [41000, 183000]
+```
+
+The lines start at the same point — `scanStringValues` makes no difference on
+the regex path. They diverge when `parseJsonStrings` is on and the object path
+is active. The embedded-credential field and stack trace add `scanStringValues`
+overhead on the object path, explaining the ~2× gap between the two
+`parseJsonStrings: true` cases.
+
+| Option combination                                            | ops/s    | ms/call |
+| ------------------------------------------------------------- | -------- | ------- |
+| `parseJsonStrings: false`, `scanStringValues: true` (default) | ~41,000  | ~0.024  |
+| `parseJsonStrings: false`, `scanStringValues: false`          | ~41,000  | ~0.024  |
+| `parseJsonStrings: true`, `scanStringValues: true`            | ~92,000  | ~0.011  |
+| `parseJsonStrings: true`, `scanStringValues: false`           | ~183,000 | ~0.0055 |
 
 ## High pattern counts
 

--- a/docs/plans/011-parser-first-json.md
+++ b/docs/plans/011-parser-first-json.md
@@ -1,0 +1,294 @@
+# Parser-First JSON String Handling
+
+## Approach
+
+When `sanitizeData` receives a string, it currently runs regex matchers across
+the raw text. This works for string-valued fields but has two meaningful gaps:
+numeric-valued sensitive fields (e.g. `{"password":12345}`) are invisible to the
+regex matchers, and the string and object paths can produce different results for
+the same logical data depending on how it arrives.
+
+This plan adds a `parseJsonStrings: boolean` option (default `false`). When
+enabled and the string is valid JSON containing an object or array, `stringReplacer`
+parses it, delegates to `objectReplacer`, and serializes the result back with
+`JSON.stringify`. If parsing fails or yields a primitive, it falls through to the
+existing regex path so non-JSON strings continue to work unchanged.
+
+The option is opt-in because `JSON.stringify` does not preserve whitespace
+formatting or key order, which would be a visible change for callers that pass
+pre-formatted JSON logs. Callers who enable it accept that tradeoff in exchange
+for consistent, type-aware sanitization.
+
+## Pre-implementation
+
+Create branch `feat/parser-first-json` from `main`.
+
+## Steps
+
+1. `docs/plans/011-parser-first-json.md` — add this plan.
+
+2. `src/types.ts` — add `parseJsonStrings?: boolean` to
+   `DataSanitizationReplacerOptions` with a TSDoc comment below `scanStringValues`:
+
+   ```typescript
+   /**
+    * Whether to parse string input as JSON and sanitize via the object
+    * path. When the input is valid JSON containing an object or array,
+    * the sanitized result is re-serialized with JSON.stringify. Falls
+    * back to regex-based sanitization when the input is not valid JSON
+    * or parses to a primitive. Has no effect on non-string input.
+    *
+    * Note: JSON.stringify does not preserve original whitespace or
+    * indentation. Enable this option only when formatting fidelity is
+    * not required.
+    *
+    * Default: false
+    */
+   parseJsonStrings?: boolean;
+   ```
+
+3. `test/replacers.test.ts` — add a `describe('parseJsonStrings option')` block
+   inside the existing `describe('stringReplacer')` block. Write all tests before
+   touching the implementation. They should fail (the option is parsed but
+   currently ignored). Cover:
+   - **Default is false / numeric fields unmasked without the option:**
+     `stringReplacer('{"password":12345,"username":"mark"}')` — `password` is
+     still `12345` in the parsed result (current behavior baseline).
+
+   - **Numeric sensitive field is masked:**
+     `stringReplacer('{"password":12345,"username":"mark"}', { parseJsonStrings: true })`
+     → `JSON.parse(result).password === DEFAULT_NUMERIC_MASK`.
+
+   - **String sensitive field is masked:**
+     `stringReplacer('{"password":"secret","username":"mark"}', { parseJsonStrings: true })`
+     → `JSON.parse(result).password === DEFAULT_PATTERN_MASK`.
+
+   - **Nested object is sanitized at all depths:**
+     `'{"user":{"password":"secret","email":"mark@example.com"},"id":1}'` with
+     `parseJsonStrings: true` → `JSON.parse(result).user.password === DEFAULT_PATTERN_MASK`,
+     `id === 1`, `email` unchanged.
+
+   - **`removeMatches: true` removes numeric fields:**
+     `'{"password":12345,"username":"mark"}'` with `{ parseJsonStrings: true, removeMatches: true }`
+     → `JSON.parse(result)` equals `{ username: 'mark' }` with no `password` key.
+
+   - **Custom `numericMask` is applied:**
+     `'{"password":12345}'` with `{ parseJsonStrings: true, numericMask: 0 }`
+     → `JSON.parse(result).password === 0`.
+
+   - **Top-level JSON array is sanitized:**
+     `'[{"password":"secret"},{"username":"mark"}]'` with `{ parseJsonStrings: true }`
+     → `JSON.parse(result)[0].password === DEFAULT_PATTERN_MASK`.
+
+   - **Falls back to regex for non-JSON strings:**
+     `'password=secret&username=mark'` with `{ parseJsonStrings: true }`
+     → result contains `password=${DEFAULT_PATTERN_MASK}` (regex path runs).
+
+   - **Falls back to regex for invalid JSON:**
+     `'{"password":"secret"'` (missing closing brace) with `{ parseJsonStrings: true }`
+     → result contains `"password":"${DEFAULT_PATTERN_MASK}"` (regex path runs).
+
+   - **Falls back to regex when JSON is a primitive:**
+     `'"hello world"'` (valid JSON string literal) with `{ parseJsonStrings: true }`
+     → result is `'"hello world"'` unchanged.
+
+   - **Result is always valid JSON when parse-first path is taken:**
+     Build a 12-field object with 2 sensitive string keys and 1 sensitive numeric
+     key; stringify it; call `stringReplacer` with `parseJsonStrings: true`;
+     assert `JSON.parse` does not throw, sensitive keys are masked, safe keys
+     are unchanged.
+
+   Run `yarn vitest run test/replacers.test.ts` — all new tests should fail
+   (option not yet implemented), existing tests should pass.
+
+4. `src/replacers.ts` — add `parseJsonStrings = false` to the destructuring in
+   `stringReplacer`, and insert the parse-first branch immediately after the
+   `typeof data !== 'string'` guard:
+
+   ```typescript
+   const {
+     customMatchers,
+     customPatterns,
+     parseJsonStrings = false,
+     patternMask,
+     removeMatches = false,
+     useDefaultMatchers = true,
+     useDefaultPatterns = true,
+   } = options;
+
+   if (typeof data !== 'string') {
+     return data;
+   }
+
+   if (parseJsonStrings) {
+     try {
+       const parsed = JSON.parse(data);
+       if (parsed !== null && typeof parsed === 'object') {
+         return JSON.stringify(objectReplacer(parsed, options));
+       }
+     } catch {
+       // not valid JSON or not an object/array — fall through to regex path
+     }
+   }
+   ```
+
+   `objectReplacer` is defined later in the same module; this is safe because
+   the function body only executes at call time, after the module has fully
+   evaluated. No import or reordering needed.
+
+   Run `yarn vitest run test/replacers.test.ts` — all tests should now pass.
+   Run `yarn test` to confirm no regressions across the full suite.
+
+5. `bench/sanitize-data.bench.ts` — add two new `describe` groups at the end of
+   the file, before the closing comment (if any). Each group pairs a
+   `parseJsonStrings: false` (default) bench against a `parseJsonStrings: true`
+   bench on the same input so the overhead difference is visible side-by-side.
+
+   **Group 1 — small JSON string (overhead case):** A 5-field object, 1 sensitive
+   string key. This is the case where parse+stringify overhead is expected to
+   dominate and `parseJsonStrings: true` should be slower:
+
+   ```typescript
+   describe('sanitizeData — JSON string, small (parseJsonStrings)', () => {
+     const input = JSON.stringify({
+       api_key: SENSITIVE_STRING_VALUE,
+       email: 'user@example.com',
+       region: 'us-east-1',
+       requestId: 'req-abc-123',
+       username: 'mark',
+     });
+
+     bench('parseJsonStrings disabled', () => {
+       sanitizeData(input);
+     });
+     bench('parseJsonStrings enabled', () => {
+       sanitizeData(input, { parseJsonStrings: true });
+     });
+   });
+   ```
+
+   **Group 2 — large JSON string (throughput case):** A 50-field object with 5
+   sensitive string keys and 5 sensitive numeric keys. This is the case where
+   avoiding 15 regex passes on a long string should make `parseJsonStrings: true`
+   competitive or faster, and it also demonstrates correct masking of numeric
+   fields which the default path cannot do:
+
+   ```typescript
+   describe('sanitizeData — JSON string, large (parseJsonStrings)', () => {
+     const input = JSON.stringify(
+       Object.fromEntries([
+         ...Array.from({ length: 40 }, (_, i) => [`field_${i}`, `value ${i}`]),
+         ...Array.from({ length: 5 }, (_, i) => [
+           `secret_${i}`,
+           SENSITIVE_STRING_VALUE,
+         ]),
+         ...Array.from({ length: 5 }, (_, i) => [`token_${i}`, i * 1000]),
+       ]),
+     );
+
+     bench('parseJsonStrings disabled', () => {
+       sanitizeData(input);
+     });
+     bench('parseJsonStrings enabled', () => {
+       sanitizeData(input, { parseJsonStrings: true });
+     });
+   });
+   ```
+
+   Run `yarn bench` and record both results in `docs/performance.md` under a new
+   "Parser-first JSON strings" section (see step 7).
+
+6. `src/index.ts` — update the TSDoc on `sanitizeData` to add a
+   `parseJsonStrings` example below the existing `scanStringValues` example:
+
+   ```typescript
+   * @example
+   * // Parse JSON string and mask numeric sensitive fields
+   * sanitizeData('{"password":12345,"username":"mark"}', { parseJsonStrings: true })
+   * // => '{"password":9999999999,"username":"mark"}'
+   ```
+
+   Also update the prose description in the function's main comment to mention
+   that when `parseJsonStrings` is enabled, valid JSON object/array strings are
+   sanitized via `objectReplacer` and re-serialized.
+
+7. `docs/performance.md` — add a "Parser-first JSON strings" section after the
+   existing "String workloads" section. Include:
+   - A brief explanation of the tradeoff (parse+stringify overhead vs. fewer regex
+     passes; correctness for numeric fields)
+   - A table with the benchmark results from step 5 (small input: `parseJsonStrings`
+     disabled vs enabled; large input: same pair)
+   - A note that the large input case also masks numeric fields correctly, which
+     the default path cannot do regardless of performance
+
+8. `README.md` — two changes:
+   - Add a `parseJsonStrings` row to the Options table directly below
+     `scanStringValues`:
+     `| \`parseJsonStrings\` | \`boolean\` | \`false\` | Parse string input as JSON and sanitize via the object path when valid. Note: re-serializes with \`JSON.stringify\`, which does not preserve original whitespace or indentation. |`
+   - Add a short example under a new "Parse JSON strings" subsection in Usage,
+     showing that a numeric sensitive field is correctly masked:
+     ```typescript
+     sanitizeData('{"password":12345,"username":"mark"}', {
+       parseJsonStrings: true,
+     });
+     // => '{"password":9999999999,"username":"mark"}'
+     ```
+
+## Relevant Files
+
+- `docs/plans/011-parser-first-json.md` — this plan (new).
+- `src/types.ts` — add `parseJsonStrings` option.
+- `src/replacers.ts` — add parse-first branch in `stringReplacer`.
+- `src/index.ts` — TSDoc update on `sanitizeData`.
+- `test/replacers.test.ts` — new `parseJsonStrings` test block in `stringReplacer` suite.
+- `bench/sanitize-data.bench.ts` — two new benchmark describe groups.
+- `docs/performance.md` — parser-first section with benchmark results.
+- `README.md` — options table row and usage example.
+
+## Verification
+
+1. `yarn test` — 100% pass, no regressions.
+2. `yarn test:coverage` — coverage stays at 100%.
+3. `yarn lint` — no violations.
+4. `yarn format:check` — clean.
+5. `yarn build` — compiled output includes `parseJsonStrings` in the type declarations.
+6. Manual spot-check: `sanitizeData('{"password":12345}', { parseJsonStrings: true })`
+   returns `'{"password":9999999999}'`; without the option returns the original
+   string with the number still present (current regex path cannot mask it).
+7. Manual spot-check: `sanitizeData('password=secret&username=mark', { parseJsonStrings: true })`
+   returns `'password=**********&username=mark'` (regex fallback works).
+
+## Decisions
+
+**Opt-in (`parseJsonStrings: false` default)** — `JSON.stringify` does not
+preserve whitespace or key order. Callers passing pre-formatted JSON logs would
+see their formatting silently altered, which is a breaking change for existing
+users. Defaulting to `false` keeps the current behavior stable and lets callers
+choose the tradeoff explicitly.
+
+**Fall through to regex when JSON parses to a primitive** — A JSON string like
+`'"hello"'` or `'42'` parses successfully but contains no key-value structure to
+sanitize. Running `objectReplacer` on a primitive returns it unchanged; serializing
+back to a string via `JSON.stringify` would produce `'"hello"'` again. Falling
+through to regex is correct behavior and avoids a no-op round-trip.
+
+**`objectReplacer` called with the full `options` object** — This means
+`numericMask`, `customPatterns`, `customMatchers`, `removeMatches`,
+`scanStringValues`, and all other options apply consistently. No option
+translation layer is needed.
+
+**`parseJsonStrings` has no effect on object input** — `objectReplacer` ignores
+the option (it doesn't destructure it). The option is meaningless on the object
+path and silently ignored, which is the correct behavior.
+
+**No explicit `JSON.stringify` error handling in `stringReplacer`** — If
+`objectReplacer` somehow produced an unserializable result, the `JSON.stringify`
+call would throw. That error bubbles up to `sanitizeData`'s existing catch block,
+which converts it to a `DataSanitizationError` with safe metadata. No additional
+handling is needed in `stringReplacer`.
+
+**Forward reference to `objectReplacer` is safe** — `stringReplacer` and
+`objectReplacer` are both `const` function expressions in the same module.
+`stringReplacer`'s function body references `objectReplacer` by closure, but the
+body only executes when the function is called — by which point `objectReplacer`
+has been assigned. No hoisting issue exists.

--- a/docs/plans/011-parser-first-json.md
+++ b/docs/plans/011-parser-first-json.md
@@ -227,6 +227,7 @@ Create branch `feat/parser-first-json` from `main`.
      `| \`parseJsonStrings\` | \`boolean\` | \`false\` | Parse string input as JSON and sanitize via the object path when valid. Note: re-serializes with \`JSON.stringify\`, which does not preserve original whitespace or indentation. |`
    - Add a short example under a new "Parse JSON strings" subsection in Usage,
      showing that a numeric sensitive field is correctly masked:
+
      ```typescript
      sanitizeData('{"password":12345,"username":"mark"}', {
        parseJsonStrings: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,12 @@ const createSafeErrorDetails = (
  * Sanitizes data in an object/string to make it safe for logging
  * or other purposes of a sensitive nature
  *
- * Strings are sanitized via {@link stringReplacer}. Non-null objects and arrays
- * are sanitized directly via {@link objectReplacer} without any string
- * conversion. Null is JSON-stringified, sanitized via {@link stringReplacer},
- * then parsed back.
+ * Strings are sanitized via {@link stringReplacer}. When `parseJsonStrings` is
+ * enabled, valid JSON object/array strings are sanitized via
+ * {@link objectReplacer} and re-serialized with `JSON.stringify`. Non-null
+ * objects and arrays are sanitized directly via {@link objectReplacer} without
+ * any string conversion. Null is JSON-stringified, sanitized via
+ * {@link stringReplacer}, then parsed back.
  *
  * @param data - String, null, or object data to be sanitized.
  * @param options - Matcher, pattern, masking, removal, and string-scan options.
@@ -86,6 +88,11 @@ const createSafeErrorDetails = (
  * // String values on non-sensitive keys are scanned for embedded patterns by default
  * sanitizeData({ message: 'request failed: api_key=hunter2' })
  * // => { message: 'request failed: api_key=**********' }
+ *
+ * @example
+ * // Parse JSON string and mask numeric sensitive fields
+ * sanitizeData('{"password":12345,"username":"mark"}', { parseJsonStrings: true })
+ * // => '{"password":9999999999,"username":"mark"}'
  */
 const sanitizeData: DataSanitizationReplacer = (data, options = {}) => {
   try {

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -122,13 +122,14 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
   }
 
   if (parseJsonStrings) {
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(data);
-      if (parsed !== null && typeof parsed === 'object') {
-        return JSON.stringify(objectReplacer(parsed, options));
-      }
+      parsed = JSON.parse(data);
     } catch {
-      // not valid JSON or not an object/array — fall through to regex path
+      // not valid JSON — fall through to regex path
+    }
+    if (parsed !== null && parsed !== undefined && typeof parsed === 'object') {
+      return JSON.stringify(objectReplacer(parsed, options));
     }
   }
 

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -110,6 +110,7 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const {
     customMatchers,
     customPatterns,
+    parseJsonStrings = false,
     patternMask,
     removeMatches = false,
     useDefaultMatchers = true,
@@ -118,6 +119,17 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
 
   if (typeof data !== 'string') {
     return data;
+  }
+
+  if (parseJsonStrings) {
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed !== null && typeof parsed === 'object') {
+        return JSON.stringify(objectReplacer(parsed, options));
+      }
+    } catch {
+      // not valid JSON or not an object/array — fall through to regex path
+    }
   }
 
   const mask = patternMask ?? DEFAULT_PATTERN_MASK;

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,20 @@ interface DataSanitizationReplacerOptions {
    */
   scanStringValues?: boolean;
   /**
+   * Whether to parse string input as JSON and sanitize via the object
+   * path. When the input is valid JSON containing an object or array,
+   * the sanitized result is re-serialized with JSON.stringify. Falls
+   * back to regex-based sanitization when the input is not valid JSON
+   * or parses to a primitive. Has no effect on non-string input.
+   *
+   * Note: JSON.stringify does not preserve original whitespace or
+   * indentation. Enable this option only when formatting fidelity is
+   * not required.
+   *
+   * Default: false
+   */
+  parseJsonStrings?: boolean;
+  /**
    * Whether to use the built-in default matchers. Default: true
    */
   useDefaultMatchers?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,9 @@ interface DataSanitizationReplacerOptions {
   /**
    * Whether to scan string values on non-sensitive-key fields for embedded
    * sensitive patterns. Disabling this improves performance on object
-   * workloads. Has no effect on string input. Default: true
+   * workloads. Has no effect on raw string input unless `parseJsonStrings`
+   * is also enabled — in that case the string is parsed to an object first
+   * and scanning applies normally. Default: true
    */
   scanStringValues?: boolean;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,20 +33,6 @@ interface DataSanitizationReplacerOptions {
    */
   numericMask?: number;
   /**
-   * A string to use as a data mask in place of the built-in default mask
-   */
-  patternMask?: string;
-  /**
-   * Whether to remove fields matched instead of masking them. Default: false
-   */
-  removeMatches?: boolean;
-  /**
-   * Whether to scan string values on non-sensitive-key fields for embedded
-   * sensitive patterns. Disabling this improves performance on object
-   * workloads. Has no effect on string input. Default: true
-   */
-  scanStringValues?: boolean;
-  /**
    * Whether to parse string input as JSON and sanitize via the object
    * path. When the input is valid JSON containing an object or array,
    * the sanitized result is re-serialized with JSON.stringify. Falls
@@ -60,6 +46,20 @@ interface DataSanitizationReplacerOptions {
    * Default: false
    */
   parseJsonStrings?: boolean;
+  /**
+   * A string to use as a data mask in place of the built-in default mask
+   */
+  patternMask?: string;
+  /**
+   * Whether to remove fields matched instead of masking them. Default: false
+   */
+  removeMatches?: boolean;
+  /**
+   * Whether to scan string values on non-sensitive-key fields for embedded
+   * sensitive patterns. Disabling this improves performance on object
+   * workloads. Has no effect on string input. Default: true
+   */
+  scanStringValues?: boolean;
   /**
    * Whether to use the built-in default matchers. Default: true
    */

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -319,6 +319,180 @@ describe('DataSanitizationReplacers', () => {
         expect(result.username).toEqual('bar');
       });
     });
+
+    describe('parseJsonStrings option', () => {
+      it('should leave numeric sensitive fields unmasked without the option', () => {
+        // Arrange
+        const testData = '{"password":12345,"username":"mark"}';
+
+        // Act
+        const result = JSON.parse(stringReplacer(testData) as string);
+
+        // Assert
+        expect(result.password).toBe(12345);
+      });
+
+      it('should mask a numeric sensitive field when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = '{"password":12345,"username":"mark"}';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: true }) as string,
+        );
+
+        // Assert
+        expect(result.password).toBe(DEFAULT_NUMERIC_MASK);
+      });
+
+      it('should mask a string sensitive field when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = '{"password":"secret","username":"mark"}';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: true }) as string,
+        );
+
+        // Assert
+        expect(result.password).toBe(DEFAULT_PATTERN_MASK);
+      });
+
+      it('should sanitize a nested object at all depths when parseJsonStrings is true', () => {
+        // Arrange
+        const testData =
+          '{"user":{"password":"secret","email":"mark@example.com"},"id":1}';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: true }) as string,
+        );
+
+        // Assert
+        expect(result.user.password).toBe(DEFAULT_PATTERN_MASK);
+        expect(result.id).toBe(1);
+        expect(result.user.email).toBe('mark@example.com');
+      });
+
+      it('should remove numeric sensitive fields when removeMatches is true', () => {
+        // Arrange
+        const testData = '{"password":12345,"username":"mark"}';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, {
+            parseJsonStrings: true,
+            removeMatches: true,
+          }) as string,
+        );
+
+        // Assert
+        expect(result).toEqual({ username: 'mark' });
+      });
+
+      it('should apply a custom numericMask to numeric sensitive fields when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = '{"password":12345}';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, {
+            numericMask: 0,
+            parseJsonStrings: true,
+          }) as string,
+        );
+
+        // Assert
+        expect(result.password).toBe(0);
+      });
+
+      it('should sanitize a top-level JSON array when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = '[{"password":"secret"},{"username":"mark"}]';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: true }) as string,
+        ) as Record<string, unknown>[];
+
+        // Assert
+        expect(result[0].password).toBe(DEFAULT_PATTERN_MASK);
+      });
+
+      it('should fall back to regex for non-JSON strings when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = 'password=secret&username=mark';
+
+        // Act
+        const result = stringReplacer(testData, {
+          parseJsonStrings: true,
+        }) as string;
+
+        // Assert
+        expect(result).toContain(`password=${DEFAULT_PATTERN_MASK}`);
+      });
+
+      it('should fall back to regex for invalid JSON when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = '{"password":"secret"';
+
+        // Act
+        const result = stringReplacer(testData, {
+          parseJsonStrings: true,
+        }) as string;
+
+        // Assert
+        expect(result).toContain(`"password":"${DEFAULT_PATTERN_MASK}"`);
+      });
+
+      it('should leave a valid JSON primitive string unchanged when parseJsonStrings is true', () => {
+        // Arrange
+        const testData = '"hello world"';
+
+        // Act
+        const result = stringReplacer(testData, {
+          parseJsonStrings: true,
+        }) as string;
+
+        // Assert
+        expect(result).toBe('"hello world"');
+      });
+
+      it('should produce valid JSON with all sensitive keys masked and safe keys intact', () => {
+        // Arrange
+        const input = {
+          apikey: 'k1',
+          city: 'Vancouver',
+          country: 'Canada',
+          email: 'mark@example.com',
+          firstName: 'Mark',
+          lastName: 'Smith',
+          password: 42,
+          postalCode: 'V6B 1A1',
+          province: 'BC',
+          secret: 'topsecret',
+          token: 'tok-abc',
+          username: 'mark',
+        };
+        const testData = JSON.stringify(input);
+
+        // Act
+        const sanitized = stringReplacer(testData, {
+          parseJsonStrings: true,
+        }) as string;
+        const parsed = JSON.parse(sanitized) as Record<string, unknown>;
+
+        // Assert
+        expect(parsed.apikey).toBe(DEFAULT_PATTERN_MASK);
+        expect(parsed.secret).toBe(DEFAULT_PATTERN_MASK);
+        expect(parsed.token).toBe(DEFAULT_PATTERN_MASK);
+        expect(parsed.password).toBe(DEFAULT_NUMERIC_MASK);
+        expect(parsed.username).toBe('mark');
+        expect(parsed.email).toBe('mark@example.com');
+        expect(parsed.firstName).toBe('Mark');
+        expect(parsed.city).toBe('Vancouver');
+      });
+    });
   });
 
   describe('objectReplacer', () => {

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -416,7 +416,9 @@ describe('DataSanitizationReplacers', () => {
         ) as Record<string, unknown>[];
 
         // Assert
+        expect(result).toHaveLength(2);
         expect(result[0].password).toBe(DEFAULT_PATTERN_MASK);
+        expect(result[1].username).toBe('mark');
       });
 
       it('should fall back to regex for non-JSON strings when parseJsonStrings is true', () => {


### PR DESCRIPTION
## Summary

- Adds `parseJsonStrings: boolean` option (default `false`) to `DataSanitizationReplacerOptions`
- When enabled, valid JSON object/array strings are parsed and sanitized via `objectReplacer`, then re-serialized with `JSON.stringify`
- Falls back to the regex path for non-JSON strings and JSON primitives
- Fixes the correctness gap where numeric-valued sensitive fields (e.g. `{"password":12345}`) are invisible to the regex path — they are now masked with `numericMask`
- 3–4× faster than the regex path for JSON string inputs

## Changes

- `src/types.ts` — adds `parseJsonStrings` option with TSDoc; clarifies `scanStringValues` interaction
- `src/replacers.ts` — parse-first branch in `stringReplacer` after the non-string guard
- `test/replacers.test.ts` — 11 tests covering numeric masking, string masking, nested objects, arrays, `removeMatches`, custom `numericMask`, and fallback paths
- `bench/sanitize-data.bench.ts` — `parseJsonStrings` benchmark groups; `parseJsonStrings × scanStringValues` interaction benchmark; 1M-item array tests marked `bench.skip`
- `docs/performance.md` — parser-first results table, interaction section with Mermaid chart, consistent ms/call units throughout
- `README.md` — options table row and recommendation, "Parse JSON strings" usage section, performance tips and cache anti-pattern warning
- `docs/ROADMAP.md` — marks parser-first item complete

## Test plan

- [ ] `yarn vitest run` — 113 tests, all passing
- [ ] `yarn build` — compiles without errors
- [ ] `yarn lint` — no violations
- [ ] `yarn bench` — benchmark suite runs (1M-item tests are skipped by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parseJsonStrings option to parse and sanitize JSON strings.

* **Documentation**
  * Expanded README, ROADMAP and performance docs with usage, options table, interaction guidance and benchmarks.
  * Added a plan documenting the parser-first JSON string behavior and test/benchmark checklist.

* **Performance**
  * Added benchmark coverage comparing parseJsonStrings and scanStringValues combinations; skipped two very large array cases.

* **Tests**
  * Added tests covering JSON-string sanitization, numeric masking and fallback behaviours.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->