### PR TITLE
refactor: simplify replacer internals and refresh benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,18 +348,18 @@ the input has and how long they are. Rough throughput on a modern laptop
 
 | Workload                                       | ops/s    | ms/call | scan overhead |
 | ---------------------------------------------- | -------- | ------- | ------------- |
-| Shallow object (1 sensitive key)               | ~243,000 | ~0.004  | ~55%          |
-| Log object, stack trace with credentials       | ~79,000  | ~0.013  | ~80%          |
-| Log object, clean stack trace                  | ~199,000 | ~0.005  | ~49%          |
-| Object with 10KB non-sensitive string          | ~143,000 | ~0.007  | ~76%          |
-| Large flat object (50 fields, 1 sensitive key) | ~69,000  | ~0.015  | ~15%          |
-| Array (1,000 items, 1 sensitive key each)      | ~2,043   | ~0.49   | ~4%           |
+| Shallow object (1 sensitive key)               | ~464,000 | ~0.002  | ~18%          |
+| Log object, stack trace with credentials       | ~46,000  | ~0.022  | ~88%          |
+| Log object, clean stack trace                  | ~318,000 | ~0.003  | ~18%          |
+| Object with 10KB non-sensitive string          | ~200,000 | ~0.005  | ~68%          |
+| Large flat object (50 fields, 1 sensitive key) | ~82,000  | ~0.012  | ~10%          |
+| Array (1,000 items, 1 sensitive key each)      | ~2,161   | ~0.46   | ~5%           |
 | Array (1,000,000 items, 1 sensitive key each)  | ~1.7     | ~574    | ~4%           |
 
-Array workloads pay ~2–4% overhead regardless of size — the per-item
+Array workloads pay ~3–5% overhead regardless of size — the per-item
 pre-filter cost is negligible. The cost is most visible on individual objects
 with long non-sensitive string values such as stack traces or large text
-fields; a single 10KB non-sensitive string value incurs ~76% overhead.
+fields; a single 10KB non-sensitive string value incurs ~68% overhead.
 
 **`scanStringValues: false`** — Disables string-value scanning on the object
 path. Use this when you control your data structure and know sensitive values
@@ -401,7 +401,7 @@ If dynamic options are unavoidable, set `scanStringValues: false` — this skips
 the string-scanning cache and avoids the fingerprinting overhead on every call.
 
 When options must genuinely vary per call, each call pays the first-call
-compilation cost (~17× slower than a cached call). For full benchmark tables,
+compilation cost (~32× slower than a cached call). For full benchmark tables,
 charts, and scaling analysis see
 [docs/performance.md](docs/performance.md). To run the suite:
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -22,25 +22,26 @@ to disabling it, sorted from highest to lowest overhead:
 ```mermaid
 xychart-beta
     title "scanStringValues overhead by workload (sorted)"
-    x-axis ["Log stack hit", "10KB string", "Log embed", "Arr-of-strs", "Shallow", "Log stack miss", "Nested", "Flat 5-key", "Flat 1-key", "Arrays"]
-    y-axis "overhead pct" 0 --> 90
-    bar [80, 76, 70, 64, 55, 49, 44, 19, 15, 3]
+    x-axis ["Log stack hit", "10KB string", "Log embed", "Arr-of-strs", "Shallow", "Log stack miss", "Nested", "Flat 1-key", "Flat 5-key", "Arrays"]
+    y-axis "overhead pct" 0 --> 100
+    bar [88, 68, 66, 47, 18, 18, 14, 10, 9, 3]
 ```
 
 Key observations:
 
-- **Log objects with long strings** pay the most — even a clean stack trace
-  with no matches incurs ~49% overhead because the pre-filter must scan a long
-  string. A matching stack trace hits ~80%.
-- **10KB non-sensitive string values** incur ~76% overhead — the pre-filter
+- **Log objects with long strings** pay the most — a stack trace containing
+  embedded credentials incurs ~88% overhead from the full regex suite running
+  on a long string. A clean stack trace (pre-filter fast-exit) still incurs
+  ~18% from the pre-filter scan alone.
+- **10KB non-sensitive string values** incur ~68% overhead — the pre-filter
   must scan the full length even when it exits immediately with no match.
-- **Array-of-strings fields** (e.g. 100 log lines) pay ~64% — per-item
+- **Array-of-strings fields** (e.g. 100 log lines) pay ~47% — per-item
   pre-filter cost accumulates across all array elements.
-- **Small shallow objects** pay ~44–55% overhead — visible but
-  sub-millisecond (~0.004–0.005 ms/call).
-- **Large flat objects** pay ~15–19% — scanning 45–49 non-sensitive fields
+- **Small shallow objects** pay ~18% overhead — visible but
+  sub-millisecond (~0.002 ms/call).
+- **Large flat objects** pay ~9–10% — scanning 45–49 non-sensitive fields
   costs less per field than scanning fewer long fields.
-- **Arrays** pay only ~2–4% — the per-item pre-filter cost is negligible
+- **Arrays** pay only ~1–5% — the per-item pre-filter cost is negligible
   compared to the work of traversing each item.
 
 ## Array scaling
@@ -54,12 +55,12 @@ xychart-beta
     title "Array throughput items per second thousands"
     x-axis ["1k items", "10k items", "100k items", "1M items"]
     y-axis "items per sec thousands" 0 --> 2400
-    line [2043, 2054, 1733, 1742]
-    line [2123, 2128, 1771, 1812]
+    line [2161, 2150, 1850, 1700]
+    line [2272, 2180, 1890, 1800]
 ```
 
 The two lines are scan enabled (lower) and scan disabled (upper). They are
-nearly indistinguishable — the ~4% gap is smaller than benchmark noise at this
+nearly indistinguishable — the ~1–5% gap is smaller than benchmark noise at this
 scale. The slight drop at 100k and 1M items reflects GC pressure from the
 large input array, not algorithmic degradation.
 
@@ -87,99 +88,99 @@ Rough throughput on a modern laptop (Apple M-series, Node.js 22):
     <tr>
       <td rowspan="2">Shallow object (4 fields)</td>
       <td>1 sensitive key</td>
-      <td>~243,000</td><td>~0.004</td>
-      <td>~545,000</td><td>~0.002</td>
-      <td>~55%</td>
+      <td>~464,000</td><td>~0.002</td>
+      <td>~563,000</td><td>~0.002</td>
+      <td>~18%</td>
     </tr>
     <tr>
       <td>4 sensitive keys (all)</td>
-      <td>~253,000</td><td>~0.004</td>
+      <td>~494,000</td><td>~0.002</td>
       <td>—</td><td>—</td>
       <td>—</td>
     </tr>
     <tr>
       <td>Deeply nested (5 levels)</td>
       <td>multiple sensitive keys</td>
-      <td>~202,000</td><td>~0.005</td>
-      <td>~363,000</td><td>~0.003</td>
-      <td>~44%</td>
+      <td>~311,000</td><td>~0.003</td>
+      <td>~362,000</td><td>~0.003</td>
+      <td>~14%</td>
     </tr>
     <tr>
       <td rowspan="3">Log object (5 fields)</td>
       <td>embedded credential in string value</td>
-      <td>~107,000</td><td>~0.009</td>
-      <td>~360,000</td><td>~0.003</td>
-      <td>~70%</td>
+      <td>~138,000</td><td>~0.007</td>
+      <td>~407,000</td><td>~0.002</td>
+      <td>~66%</td>
     </tr>
     <tr>
       <td>stack trace with embedded credentials</td>
-      <td>~79,000</td><td>~0.013</td>
-      <td>~388,000</td><td>~0.003</td>
-      <td>~80%</td>
+      <td>~46,000</td><td>~0.022</td>
+      <td>~387,000</td><td>~0.003</td>
+      <td>~88%</td>
     </tr>
     <tr>
       <td>clean stack trace (pre-filter fast-exit)</td>
-      <td>~199,000</td><td>~0.005</td>
-      <td>~389,000</td><td>~0.003</td>
-      <td>~49%</td>
+      <td>~318,000</td><td>~0.003</td>
+      <td>~387,000</td><td>~0.003</td>
+      <td>~18%</td>
     </tr>
     <tr>
       <td>Many embedded matches (21 fields)</td>
       <td>20 string values all containing a pattern</td>
-      <td>~13,000</td><td>~0.077</td>
+      <td>~14,000</td><td>~0.072</td>
       <td>—</td><td>—</td>
       <td>—</td>
     </tr>
     <tr>
       <td rowspan="2">Large flat object (50 fields)</td>
       <td>1 sensitive key</td>
-      <td>~69,000</td><td>~0.015</td>
-      <td>~80,000</td><td>~0.012</td>
-      <td>~15%</td>
+      <td>~82,000</td><td>~0.012</td>
+      <td>~91,000</td><td>~0.011</td>
+      <td>~10%</td>
     </tr>
     <tr>
       <td>5 sensitive keys</td>
-      <td>~69,000</td><td>~0.015</td>
-      <td>~86,000</td><td>~0.012</td>
-      <td>~19%</td>
+      <td>~81,000</td><td>~0.012</td>
+      <td>~89,000</td><td>~0.011</td>
+      <td>~9%</td>
     </tr>
     <tr>
       <td rowspan="2">Object with 10KB string field</td>
       <td>1 sensitive key + 10KB non-sensitive value</td>
-      <td>~143,000</td><td>~0.007</td>
-      <td>~596,000</td><td>~0.002</td>
-      <td>~76%</td>
+      <td>~200,000</td><td>~0.005</td>
+      <td>~619,000</td><td>~0.002</td>
+      <td>~68%</td>
     </tr>
     <tr>
       <td>array-of-strings field (100 clean log lines)</td>
-      <td>~151,000</td><td>~0.007</td>
-      <td>~415,000</td><td>~0.002</td>
-      <td>~64%</td>
+      <td>~223,000</td><td>~0.004</td>
+      <td>~425,000</td><td>~0.002</td>
+      <td>~47%</td>
     </tr>
     <tr>
       <td>Deeply nested (5 × 10 safe strings)</td>
       <td>5 levels, 10 non-sensitive string fields each</td>
-      <td>~29,000</td><td>~0.035</td>
+      <td>~30,000</td><td>~0.033</td>
       <td>~32,000</td><td>~0.031</td>
-      <td>~11%</td>
+      <td>~6%</td>
     </tr>
     <tr>
       <td rowspan="4">Array — simple items<br>(3 fields: 1 sensitive)</td>
       <td>1,000 items</td>
-      <td>~2,043</td><td>~0.49</td>
-      <td>~2,123</td><td>~0.47</td>
-      <td>~4%</td>
+      <td>~2,161</td><td>~0.46</td>
+      <td>~2,272</td><td>~0.44</td>
+      <td>~5%</td>
     </tr>
     <tr>
       <td>10,000 items</td>
-      <td>~205</td><td>~4.9</td>
-      <td>~213</td><td>~4.7</td>
-      <td>~4%</td>
+      <td>~215</td><td>~4.7</td>
+      <td>~218</td><td>~4.6</td>
+      <td>~1%</td>
     </tr>
     <tr>
       <td>100,000 items</td>
-      <td>~17</td><td>~58</td>
-      <td>~18</td><td>~56</td>
+      <td>~18</td><td>~54</td>
+      <td>~19</td><td>~53</td>
       <td>~2%</td>
     </tr>
     <tr>
@@ -191,20 +192,20 @@ Rough throughput on a modern laptop (Apple M-series, Node.js 22):
     <tr>
       <td rowspan="4">Array — complex items<br>(10 fields: 5 sensitive)</td>
       <td>1,000 items</td>
-      <td>~516</td><td>~1.94</td>
-      <td>~539</td><td>~1.86</td>
-      <td>~4%</td>
+      <td>~590</td><td>~1.69</td>
+      <td>~565</td><td>~1.77</td>
+      <td>~0%</td>
     </tr>
     <tr>
       <td>10,000 items</td>
-      <td>~51</td><td>~19.5</td>
-      <td>~53</td><td>~18.9</td>
-      <td>~3%</td>
+      <td>~55</td><td>~18.1</td>
+      <td>~58</td><td>~17.2</td>
+      <td>~5%</td>
     </tr>
     <tr>
       <td>100,000 items</td>
-      <td>~5.0</td><td>~201</td>
-      <td>~5.0</td><td>~201</td>
+      <td>~5.3</td><td>~191</td>
+      <td>~5.3</td><td>~187</td>
       <td>~0%</td>
     </tr>
     <tr>
@@ -231,10 +232,10 @@ reuse the cache and pay no compile cost.
 
 | Case                                 | ops/s    | ms/call |
 | ------------------------------------ | -------- | ------- |
-| Warm cache (same options each call)  | ~246,000 | ~0.004  |
+| Warm cache (same options each call)  | ~451,000 | ~0.002  |
 | Cold start (unique options per call) | ~14,000  | ~0.070  |
 
-The first call is ~17× slower than a warm call due to regex compilation.
+The first call is ~32× slower than a warm call due to regex compilation.
 In steady-state server usage this cost is paid once per process lifetime and
 is negligible. It becomes visible only in tests or scripts that create many
 distinct option configurations (e.g. per-request custom patterns).
@@ -267,27 +268,27 @@ replacement pattern differences.
   <tbody>
     <tr>
       <td>Shallow object (4 fields, 1 sensitive)</td>
-      <td>~234,000</td><td>~0.004</td>
-      <td>~234,000</td><td>~0.004</td>
+      <td>~440,000</td><td>~0.002</td>
+      <td>~441,000</td><td>~0.002</td>
       <td>~0%</td>
     </tr>
     <tr>
       <td>Large flat object (50 fields, 1 sensitive)</td>
-      <td>~68,000</td><td>~0.015</td>
-      <td>~61,000</td><td>~0.016</td>
-      <td>~11%</td>
+      <td>~80,000</td><td>~0.013</td>
+      <td>~77,000</td><td>~0.013</td>
+      <td>~3%</td>
     </tr>
     <tr>
       <td>Array (1,000 items, 1 sensitive key)</td>
-      <td>~2,096</td><td>~0.48</td>
-      <td>~1,979</td><td>~0.51</td>
-      <td>~6%</td>
+      <td>~2,132</td><td>~0.47</td>
+      <td>~2,167</td><td>~0.46</td>
+      <td>~0%</td>
     </tr>
     <tr>
       <td>Form-encoded string</td>
-      <td>~101,000</td><td>~0.010</td>
+      <td>~104,000</td><td>~0.010</td>
       <td>~81,000</td><td>~0.012</td>
-      <td>~20%</td>
+      <td>~22%</td>
     </tr>
   </tbody>
 </table>
@@ -336,15 +337,15 @@ regex path cannot detect or replace bare numeric values in strings.
   <tbody>
     <tr>
       <td>Small JSON string (5 fields, 1 sensitive)</td>
-      <td>~65,783</td><td>~0.0152</td>
-      <td>~271,150</td><td>~0.0037</td>
-      <td>~4.1×</td>
+      <td>~78,073</td><td>~0.0128</td>
+      <td>~312,452</td><td>~0.0032</td>
+      <td>~4.0×</td>
     </tr>
     <tr>
       <td>Large JSON string (50 fields, 5 sensitive string + 5 sensitive numeric)</td>
-      <td>~17,164</td><td>~0.0583</td>
-      <td>~50,848</td><td>~0.0197</td>
-      <td>~3.0×</td>
+      <td>~17,608</td><td>~0.0568</td>
+      <td>~58,763</td><td>~0.0170</td>
+      <td>~3.3×</td>
     </tr>
   </tbody>
 </table>
@@ -371,8 +372,8 @@ xychart-beta
     title "parseJsonStrings x scanStringValues interaction (15-field log payload, ops/s)"
     x-axis ["parseJsonStrings off", "parseJsonStrings on"]
     y-axis "ops/s" 0 --> 200000
-    line [41000, 92000]
-    line [41000, 183000]
+    line [43000, 92000]
+    line [43000, 181000]
 ```
 
 The lines start at the same point — `scanStringValues` makes no difference on
@@ -383,10 +384,10 @@ overhead on the object path, explaining the ~2× gap between the two
 
 | Option combination                                            | ops/s    | ms/call |
 | ------------------------------------------------------------- | -------- | ------- |
-| `parseJsonStrings: false`, `scanStringValues: true` (default) | ~41,000  | ~0.024  |
-| `parseJsonStrings: false`, `scanStringValues: false`          | ~41,000  | ~0.024  |
+| `parseJsonStrings: false`, `scanStringValues: true` (default) | ~43,000  | ~0.023  |
+| `parseJsonStrings: false`, `scanStringValues: false`          | ~43,000  | ~0.023  |
 | `parseJsonStrings: true`, `scanStringValues: true`            | ~92,000  | ~0.011  |
-| `parseJsonStrings: true`, `scanStringValues: false`           | ~183,000 | ~0.0055 |
+| `parseJsonStrings: true`, `scanStringValues: false`           | ~181,000 | ~0.0055 |
 
 ## High pattern counts
 
@@ -413,7 +414,7 @@ In steady-state usage — a fixed configuration, possibly with a static list of
 
 If `customPatterns` vary per call (e.g. injected from user input or request
 data), entries will cycle through the cache and every call will pay the
-cold-start regex compilation cost (~17× slower than a warm call). In that
+cold-start regex compilation cost (~32× slower than a warm call). In that
 scenario, prebuild the options object once (or a small set of them) and reuse
 it across calls. Or set `scanStringValues: false`, which bypasses the cache
 entirely.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ const DEFAULT_FIELD_NAME_PATTERNS = [
 ];
 
 /**
- * A default pattern used when replacing string field values.
+ * A default mask used when replacing string field values.
  */
 const DEFAULT_PATTERN_MASK = '**********';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,6 @@ import { DataSanitizationReplacer } from './types';
  * // => 'object'
  */
 const getInputType = (data: unknown): string => {
-  if (data === null) {
-    return 'null';
-  }
-
   if (Array.isArray(data)) {
     return 'array';
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,14 +58,12 @@ const createSafeErrorDetails = (
  * enabled, valid JSON object/array strings are sanitized via
  * {@link objectReplacer} and re-serialized with `JSON.stringify`. Non-null
  * objects and arrays are sanitized directly via {@link objectReplacer} without
- * any string conversion. Null is JSON-stringified, sanitized via
- * {@link stringReplacer}, then parsed back.
+ * any string conversion. Null is returned as-is.
  *
  * @param data - String, null, or object data to be sanitized.
  * @param options - Matcher, pattern, masking, removal, and string-scan options.
  * @returns Sanitized data in the original supported input type when possible.
  * @throws {DataSanitizationError} When the input data type cannot be sanitized.
- * @throws {DataSanitizationError} When sanitized object data cannot be parsed back to JSON.
  *
  * @example
  * // Sanitize a JSON string
@@ -98,12 +96,11 @@ const sanitizeData: DataSanitizationReplacer = (data, options = {}) => {
       return stringReplacer(data, options);
     }
 
+    if (data === null) {
+      return null;
+    }
+
     if (typeof data === 'object') {
-      if (data === null) {
-        return JSON.parse(
-          stringReplacer(JSON.stringify(data), options) as string,
-        );
-      }
       return objectReplacer(data, options);
     }
 

--- a/src/replacers.ts
+++ b/src/replacers.ts
@@ -6,28 +6,42 @@ import {
 } from './constants';
 import defaultMatchers, { escapePattern } from './matchers';
 
+/**
+ * Builds the active pattern list from defaults and any caller-supplied patterns.
+ *
+ * @param useDefaultPatterns - Whether to include the built-in default patterns.
+ * @param customPatterns - Additional patterns to append to the active list.
+ * @returns Combined array of field-name patterns to match against.
+ */
 const buildPatterns = (
   useDefaultPatterns: boolean,
   customPatterns?: string[],
-): string[] => {
-  const base = useDefaultPatterns ? [...DEFAULT_FIELD_NAME_PATTERNS] : [];
-  return Array.isArray(customPatterns) ? [...base, ...customPatterns] : base;
-};
+): string[] => [
+  ...(useDefaultPatterns ? DEFAULT_FIELD_NAME_PATTERNS : []),
+  ...(customPatterns ?? []),
+];
 
+/**
+ * Builds the active matcher list from defaults and any caller-supplied matchers.
+ *
+ * @param useDefaultMatchers - Whether to include the built-in default matchers.
+ * @param customMatchers - Additional matchers to append to the active list.
+ * @returns Combined array of matchers used to build replacement regexes.
+ */
 const buildMatchers = (
   useDefaultMatchers: boolean,
   customMatchers?: DataSanitizationMatcher[],
-): DataSanitizationMatcher[] => {
-  const base = useDefaultMatchers ? [...defaultMatchers] : [];
-  return Array.isArray(customMatchers) ? [...base, ...customMatchers] : base;
-};
+): DataSanitizationMatcher[] => [
+  ...(useDefaultMatchers ? defaultMatchers : []),
+  ...(customMatchers ?? []),
+];
 
 interface StringScanRegexes {
   preFilter: RegExp | null;
   regexes: RegExp[];
 }
 
-const STRING_SCAN_CACHE_MAX = 10;
+export const STRING_SCAN_CACHE_MAX = 10;
 const stringScanCache = new Map<string, StringScanRegexes>();
 
 // Assign stable numeric IDs to matcher functions by object identity so that
@@ -35,6 +49,15 @@ const stringScanCache = new Map<string, StringScanRegexes>();
 const matcherIds = new WeakMap<DataSanitizationMatcher, number>();
 let matcherIdCounter = 0;
 
+/**
+ * Returns a stable string ID for a matcher function by object identity.
+ *
+ * Assigns a new ID on first encounter and caches it in a WeakMap so that two
+ * closures with identical source but different captured state do not collide.
+ *
+ * @param matcher - Matcher function to identify.
+ * @returns Stable numeric string ID for the matcher.
+ */
 const getMatcherId = (matcher: DataSanitizationMatcher): string => {
   const existing = matcherIds.get(matcher);
   if (existing !== undefined) {
@@ -45,6 +68,18 @@ const getMatcherId = (matcher: DataSanitizationMatcher): string => {
   return String(id);
 };
 
+/**
+ * Builds and caches the pre-filter and per-pattern regexes used when scanning
+ * non-sensitive string values for embedded sensitive patterns.
+ *
+ * Results are keyed by matcher identity, pattern list, and removeMatches flag,
+ * and stored in an LRU cache capped at {@link STRING_SCAN_CACHE_MAX} entries.
+ *
+ * @param matchers - Active matcher functions.
+ * @param patterns - Active field-name patterns.
+ * @param removeMatches - Whether matchers should target removal instead of masking.
+ * @returns Pre-filter regex (or `null` when no patterns are active) and per-pattern replacement regexes.
+ */
 const buildStringScanRegexes = (
   matchers: DataSanitizationMatcher[],
   patterns: string[],
@@ -89,14 +124,9 @@ const buildStringScanRegexes = (
  * This checks for some common patterns on how sensitive
  * data might appear in a string.
  *
- * NOTE: these are not meant to cover every case, but common cases
- *       care should still be taken in code to ensure only logging of
- *       safe data
- *
  * @param data - Data string to be sanitized.
  * @param options - Matcher, pattern, masking, and removal options.
  * @returns Sanitized string data, or the original non-string data for runtime safety.
- * @throws {Error} If a matcher fails while creating a regular expression for a pattern.
  *
  * @example
  * stringReplacer('password=secret&username=mark')
@@ -137,15 +167,10 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const patterns = buildPatterns(useDefaultPatterns, customPatterns);
   const matchers = buildMatchers(useDefaultMatchers, customMatchers);
 
+  const replacement = removeMatches ? '' : '$1' + mask + '$2';
   for (const pattern of patterns) {
     for (const matcher of matchers) {
-      const matchInstance = matcher(pattern, removeMatches);
-
-      if (removeMatches) {
-        data = data.replace(matchInstance, '');
-      } else {
-        data = data.replace(matchInstance, '$1' + mask + '$2');
-      }
+      data = data.replace(matcher(pattern, removeMatches), replacement);
     }
   }
 
@@ -202,15 +227,14 @@ const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
       : { preFilter: null, regexes: [] };
   const seen = new WeakSet<object>();
 
+  const stringScanReplacement = removeMatches ? '' : '$1' + mask + '$2';
   const scanStringValue = (value: string): string => {
     if (!patternPreFilter?.test(value)) {
       return value;
     }
     let result = value;
     for (const regex of stringRegexes) {
-      result = removeMatches
-        ? result.replace(regex, '')
-        : result.replace(regex, '$1' + mask + '$2');
+      result = result.replace(regex, stringScanReplacement);
     }
     return result;
   };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,10 +6,6 @@ import sanitizeData from '../src/index';
 import { DataSanitizationError } from '../src/errors';
 import { DEFAULT_NUMERIC_MASK, DEFAULT_PATTERN_MASK } from '../src/constants';
 
-const failingMatcher = (): RegExp => {
-  throw new Error('matcher failed');
-};
-
 describe('DataSanitizationIndexAndErrors', () => {
   describe('sanitizeData', () => {
     it('should sanitize top-level object input', () => {
@@ -184,7 +180,7 @@ describe('DataSanitizationIndexAndErrors', () => {
       expect(output).toContain('username=bar');
     });
 
-    it('should pass options through to the replacer', () => {
+    it('should use a custom patternMask when provided', () => {
       // Arrange
       const input = { password: 'foo', username: 'bar' };
 
@@ -269,36 +265,6 @@ describe('DataSanitizationIndexAndErrors', () => {
       expect((thrownError as DataSanitizationError).details).toEqual({
         errorName: 'TypeError',
         inputType: 'object',
-      });
-    });
-
-    it('should report null input type in wrapped error details', () => {
-      // Arrange
-      const input = null as unknown as Record<string, unknown>;
-      let thrownError: unknown;
-
-      // Act
-      const act = (): void => {
-        try {
-          sanitizeData(input, {
-            customMatchers: [failingMatcher],
-            customPatterns: ['password'],
-            useDefaultMatchers: false,
-            useDefaultPatterns: false,
-          });
-        } catch (error) {
-          thrownError = error;
-          throw error;
-        }
-      };
-
-      // Assert
-      expect(act).toThrowError(DataSanitizationError);
-      expect(act).toThrowError('Error parsing data');
-      expect(thrownError).toBeInstanceOf(DataSanitizationError);
-      expect((thrownError as DataSanitizationError).details).toEqual({
-        errorName: 'Error',
-        inputType: 'null',
       });
     });
 

--- a/test/replacers.test.ts
+++ b/test/replacers.test.ts
@@ -2,7 +2,11 @@
 import { describe, expect, it } from 'vitest';
 
 /* local imports */
-import { objectReplacer, stringReplacer } from '../src/replacers';
+import {
+  objectReplacer,
+  stringReplacer,
+  STRING_SCAN_CACHE_MAX,
+} from '../src/replacers';
 import { DEFAULT_NUMERIC_MASK, DEFAULT_PATTERN_MASK } from '../src/constants';
 
 const headerMatcher = (pattern: string) =>
@@ -968,10 +972,9 @@ describe('DataSanitizationReplacers', () => {
         expect(result.username).toEqual('mark');
       });
 
-      it('should treat two closures with identical source but different captured state as distinct cache entries', () => {
-        // Arrange — same factory produces closures with identical source text but
-        // different captured prefix; toString()-based keys would collide and use
-        // the first closure's regexes for all subsequent calls with identical source
+      it('should apply each custom matcher independently when matchers differ in captured state', () => {
+        // Arrange — two matchers built from the same factory with different
+        // captured prefixes: matcherA targets a_-prefixed keys, matcherB targets b_-prefixed keys
         const makeCustomMatcher =
           (prefix: string) =>
           (pattern: string): RegExp =>
@@ -988,7 +991,7 @@ describe('DataSanitizationReplacers', () => {
           useDefaultPatterns: false,
         };
 
-        // Act — prime the cache with matcherA, then apply matcherB
+        // Act — sanitize with matcherA first, then with matcherB
         objectReplacer(testData, {
           ...sharedOptions,
           customMatchers: [matcherA],
@@ -998,26 +1001,25 @@ describe('DataSanitizationReplacers', () => {
           customMatchers: [matcherB],
         }) as Record<string, unknown>;
 
-        // Assert — matcherB should mask b_key only; a cache collision would
-        // return matcherA's regexes and mask a_key instead
+        // Assert — matcherB targets b_-prefixed keys only; a_key should be unchanged
         expect(result.log).toContain(`b_key=${DEFAULT_PATTERN_MASK}`);
         expect(result.log).toContain('a_key=AVALUE');
       });
 
-      it('should return correct results after string-scan cache eviction', () => {
-        // Arrange — fill the cache past the 10-entry cap with distinct configs
+      it('should produce correct results when a config is reused after many other configs have been used', () => {
+        // Arrange — fill the cache past the cap with distinct configs
         const testData = {
           log: 'custom_0=secret&other=safe',
           username: 'mark',
         };
-        for (let i = 0; i < 11; i++) {
+        for (let i = 0; i < STRING_SCAN_CACHE_MAX + 10; i++) {
           objectReplacer(testData, {
             customPatterns: [`custom_${i}`],
             useDefaultPatterns: false,
           });
         }
 
-        // Act — re-use the first config, which was evicted; must still work
+        // Act
         const result = objectReplacer(testData, {
           customPatterns: ['custom_0'],
           useDefaultPatterns: false,


### PR DESCRIPTION
# Overview

Cleans up replacer internals following the v1.1.1 release and refreshes benchmark numbers to reflect current performance.

## Details

- `sanitizeData` returns `null` directly instead of a JSON round-trip (`null` has no fields or string values to sanitize)
- `buildPatterns` / `buildMatchers` simplified to concise spread with `??`, removing redundant `Array.isArray` guards and intermediate variables
- Replacement string (`'$1' + mask + '$2'` or `''`) hoisted out of inner loops in both `stringReplacer` and `objectReplacer`
- `STRING_SCAN_CACHE_MAX` exported so `{@link}` in TSDoc resolves and tests can reference it without a magic number
- TSDoc added to `buildPatterns`, `buildMatchers`, `getMatcherId`, and `buildStringScanRegexes`
- Duplicate null test and orphaned `failingMatcher` removed; cache eviction test loop bound tied to `STRING_SCAN_CACHE_MAX`
- Benchmark numbers in README and `docs/performance.md` refreshed

## Related Tickets and/or Pull Requests

<!-- None -->

## Checklist

- [x] Tests added or updated
- [x] README and TSDoc updated if the public API changed
- [ ] Breaking changes called out (if any)
- [ ] Roadmap item checked off if this PR completes one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated performance benchmarks with revised throughput, latency, and overhead metrics across various workload scenarios.

* **Changes**
  * Improved null input handling in sanitizeData for more efficient processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->