### PR TITLE
fix(ci): declare yargs in data-sanitization devDependencies

### DIFF
--- a/packages/data-sanitization/package.json
+++ b/packages/data-sanitization/package.json
@@ -58,7 +58,8 @@
     "@vitest/coverage-v8": "^4.1.6",
     "query-string": "^9.3.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "yargs": "^18.0.0"
   },
   "engines": {
     "node": ">=22.22.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,6 +1624,7 @@ __metadata:
     query-string: "npm:^9.3.1"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
+    yargs: "npm:^18.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Overview

- Fixes CI failure in the `Update coverage report in Gist` step introduced by the monorepo migration

## Details

`update-coverage-gist.mjs` uses `yargs`, which was only declared in the root `package.json`. Yarn 4 PnP enforces strict dependency isolation — each workspace package can only access packages explicitly declared in its own `package.json`. Added `yargs` to `packages/data-sanitization/devDependencies`.

## Related Tickets and/or Pull Requests

Relates to #308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies in the data-sanitization package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->