### PR TITLE
feat(307): add /utils subpath export with diffSanitizedFields and buildSanitizedWarning

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ import sanitizeData from 'data-sanitization';
 const { sanitizeData } = require('data-sanitization');
 ```
 
+Utility helpers for log middleware are available on a separate subpath —
+see [docs/utils.md](docs/utils.md).
+
+```typescript
+import {
+  diffSanitizedFields,
+  buildSanitizedWarning,
+} from 'data-sanitization/utils';
+```
+
 ## Usage
 
 ### Quick start

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,172 @@
+# `data-sanitization/utils`
+
+Helper functions for log middleware. Import from the `data-sanitization/utils`
+subpath — they are not included in the main `data-sanitization` export.
+
+```typescript
+import {
+  diffSanitizedFields,
+  buildSanitizedWarning,
+} from 'data-sanitization/utils';
+```
+
+## Why these exist
+
+When you use `sanitizeData` in a log transport or write hook, you often need
+to do more than just mask values. You need to know **which fields changed** so
+you can:
+
+- Emit a warning log entry alongside the sanitized one, making the
+  sanitization event visible in your log aggregator even after the raw data is
+  gone.
+- Increment a counter or fire an alert when sensitive data is found in a log
+  entry (a signal that something upstream is leaking credentials or PII into
+  logs).
+- Record an audit trail of which fields were sanitized and when.
+
+`diffSanitizedFields` answers "what changed?" and `buildSanitizedWarning`
+turns that answer into a ready-to-emit warning log line.
+
+## `diffSanitizedFields`
+
+```typescript
+diffSanitizedFields(original: object, sanitized: object): string[]
+```
+
+Recursively diffs two objects and returns the dot/bracket-notation paths of
+every field whose value changed. Designed to be called with the original
+payload and the output of `sanitizeData`.
+
+- Object keys use **dot notation**: `user.email`
+- Array indices use **bracket notation**: `tokens[0]`, `users[0].email`
+- Keys present in `original` but absent in `sanitized` are included — this
+  covers the `removeMatches: true` case where fields are deleted rather than
+  masked.
+- Keys present in `sanitized` but not in `original` are ignored — the diff
+  is one-directional, walking `original`'s keys.
+
+### Examples
+
+```typescript
+// Nested object field
+diffSanitizedFields(
+  { user: { email: 'a@b.com', id: 1 }, msg: 'login' },
+  { user: { email: '**********', id: 1 }, msg: 'login' },
+);
+// => ['user.email']
+
+// Array element values
+diffSanitizedFields(
+  { tokens: ['abc', 'def'] },
+  { tokens: ['**********', '**********'] },
+);
+// => ['tokens[0]', 'tokens[1]']
+
+// Nested field inside an array element
+diffSanitizedFields(
+  { users: [{ email: 'a@b.com', id: 1 }] },
+  { users: [{ email: '**********', id: 1 }] },
+);
+// => ['users[0].email']
+
+// Field removed by removeMatches: true
+diffSanitizedFields(
+  { password: 'secret', username: 'mark' },
+  { username: 'mark' },
+);
+// => ['password']
+
+// No changes
+diffSanitizedFields({ msg: 'hello' }, { msg: 'hello' });
+// => []
+```
+
+## `buildSanitizedWarning`
+
+```typescript
+buildSanitizedWarning(
+  originalStr: string,
+  sanitizedStr: string,
+  options?: { allowedFields?: string[] },
+): string | null
+```
+
+Parses two JSON log strings, diffs them, and builds a structured warning log
+entry identifying which fields were sanitized. Returns `null` when no warning
+is needed.
+
+The warning entry:
+
+- Carries all non-changed fields from the **sanitized** log object (safe
+  values only — the changed fields are excluded from the warning body since
+  they appear in the `fields` array).
+- Overrides `level` to `40` (warn) and `msg` to
+  `"sensitive data found in log entry"`.
+- Adds a `fields` array with the dot/bracket-notation paths that changed.
+
+Returns `null` when:
+
+- Either string is not valid JSON.
+- Either string parses to something other than a plain object (e.g. an array
+  or `null`).
+- No fields differ between the two inputs (nothing to warn about).
+
+### `options.allowedFields`
+
+By default, all non-changed fields from the sanitized object carry over into
+the warning. Pass `allowedFields` to restrict the warning to a specific set
+of context fields — useful in log-provider integrations where you want only
+correlation metadata (e.g. `time`, `pid`, `hostname`) and nothing else.
+
+### Usage examples
+
+```typescript
+const original =
+  '{"level":30,"time":1716667200000,"pid":12345,"hostname":"api-1","email":"mark@example.com","msg":"user login"}';
+const sanitized =
+  '{"level":30,"time":1716667200000,"pid":12345,"hostname":"api-1","email":"**********","msg":"user login"}';
+
+buildSanitizedWarning(original, sanitized);
+// => '{"time":1716667200000,"pid":12345,"hostname":"api-1","level":40,"msg":"sensitive data found in log entry","fields":["email"]}'
+```
+
+```typescript
+// Restrict which context fields appear in the warning
+buildSanitizedWarning(original, sanitized, {
+  allowedFields: ['time', 'pid', 'hostname'],
+});
+// => '{"time":1716667200000,"pid":12345,"hostname":"api-1","level":40,"msg":"sensitive data found in log entry","fields":["email"]}'
+```
+
+```typescript
+// Returns null — nothing changed
+buildSanitizedWarning(sanitized, sanitized);
+// => null
+
+// Returns null — not valid JSON
+buildSanitizedWarning('plain text log line', sanitized);
+// => null
+```
+
+### Typical log middleware pattern
+
+```typescript
+import { sanitizeData } from 'data-sanitization';
+import { buildSanitizedWarning } from 'data-sanitization/utils';
+
+function sanitizeLogLine(raw: string): string {
+  const sanitized = sanitizeData(raw, { parseJsonStrings: true }) as string;
+
+  // No change — emit as-is
+  if (sanitized === raw) return raw;
+
+  const warning = buildSanitizedWarning(raw, sanitized);
+
+  // Prepend warning so the event is visible in log aggregators
+  return warning ? warning + '\n' + sanitized : sanitized;
+}
+```
+
+The `data-sanitization-log-providers` package (see
+[ROADMAP.md](ROADMAP.md)) will ship ready-made adapters for pino, winston,
+and bunyan that use this pattern internally.

--- a/packages/data-sanitization/package.json
+++ b/packages/data-sanitization/package.json
@@ -39,6 +39,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "default": "./dist/utils.js"
     }
   },
   "publishConfig": {

--- a/packages/data-sanitization/src/types.ts
+++ b/packages/data-sanitization/src/types.ts
@@ -82,6 +82,18 @@ interface DataSanitizationReplacerOptions {
 }
 
 /**
+ * Options for {@link buildSanitizedWarning}.
+ */
+interface BuildSanitizedWarningOptions {
+  /**
+   * An explicit list of field names to carry over from the sanitized log
+   * object into the warning entry. When omitted, all fields whose values
+   * did not change are included.
+   */
+  allowedFields?: string[];
+}
+
+/**
  * Data accepted by sanitization replacers.
  */
 type DataSanitizationInput = string | object | null;
@@ -111,6 +123,7 @@ type DataSanitizationReplacer = (
 ) => DataSanitizationOutput;
 
 export {
+  BuildSanitizedWarningOptions,
   DataSanitizationInput,
   DataSanitizationMatcher,
   DataSanitizationOutput,

--- a/packages/data-sanitization/src/utils.ts
+++ b/packages/data-sanitization/src/utils.ts
@@ -1,0 +1,187 @@
+import { BuildSanitizedWarningOptions } from './types';
+
+/**
+ * Recursively diffs two objects and returns dot-notation paths for any keys
+ * whose values changed. Object keys use dot notation (`user.email`); array
+ * indices use bracket notation (`items[0].password`). Keys present in
+ * `original` but absent in `sanitized` are included (covers `removeMatches`
+ * behaviour).
+ *
+ * @param original - The original, unsanitized object.
+ * @param sanitized - The sanitized object produced by `sanitizeData`.
+ * @returns Dot/bracket-notation paths of every field that changed.
+ *
+ * @example
+ * diffSanitizedFields(
+ *   { user: { email: 'a@b.com' }, msg: 'hi' },
+ *   { user: { email: '**********' }, msg: 'hi' },
+ * )
+ * // => ['user.email']
+ *
+ * @example
+ * diffSanitizedFields(
+ *   { tokens: ['abc', 'def'] },
+ *   { tokens: ['**********', '**********'] },
+ * )
+ * // => ['tokens[0]', 'tokens[1]']
+ */
+const diffSanitizedFields = (original: object, sanitized: object): string[] => {
+  const changed: string[] = [];
+
+  const walk = (a: unknown, b: unknown, path: string): void => {
+    if (a === b) {
+      return;
+    }
+
+    const aIsObj = typeof a === 'object' && a !== null;
+    const bIsObj = typeof b === 'object' && b !== null;
+
+    if (!aIsObj || !bIsObj) {
+      /* istanbul ignore next -- path is always non-empty at a nested call site;
+         reaching here with path='' requires a null/primitive root, which violates
+         the public API contract */
+      if (path) {
+        changed.push(path);
+      }
+      return;
+    }
+
+    if (Array.isArray(a) && Array.isArray(b)) {
+      const len = Math.max(a.length, b.length);
+      for (let i = 0; i < len; i++) {
+        walk(a[i], b[i], path ? `${path}[${i}]` : `[${i}]`);
+      }
+      return;
+    }
+
+    if (Array.isArray(a) !== Array.isArray(b)) {
+      if (path) {
+        changed.push(path);
+      }
+      return;
+    }
+
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+
+    for (const key of Object.keys(aObj)) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (!(key in bObj)) {
+        changed.push(childPath);
+      } else {
+        walk(aObj[key], bObj[key], childPath);
+      }
+    }
+  };
+
+  walk(original, sanitized, '');
+  return changed;
+};
+
+const WARN_LEVEL = 40;
+const WARN_MSG = 'sensitive data found in log entry';
+
+const isPlainObj = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * Extracts the top-level key from a dot/bracket-notation path.
+ *
+ * @param path - A dot/bracket-notation field path.
+ * @returns The key segment before the first `.` or `[`.
+ *
+ * @example
+ * topLevelKey('user.email')  // => 'user'
+ * topLevelKey('items[0].x') // => 'items'
+ * topLevelKey('email')       // => 'email'
+ */
+const topLevelKey = (path: string): string => {
+  const dot = path.indexOf('.');
+  const bracket = path.indexOf('[');
+  if (dot === -1 && bracket === -1) {
+    return path;
+  }
+  if (dot === -1) {
+    return path.slice(0, bracket);
+  }
+  if (bracket === -1) {
+    return path.slice(0, dot);
+  }
+  return path.slice(0, Math.min(dot, bracket));
+};
+
+/**
+ * Builds a structured warning log entry from two JSON strings identifying
+ * which fields were sanitized. Suitable for use with pino, winston, bunyan,
+ * or any JSON-line logger.
+ *
+ * The warning entry carries all non-changed fields from the sanitized log
+ * object (or only the fields named in `options.allowedFields` when provided),
+ * overrides `level` to `40` (warn) and `msg` to a fixed warning string, and
+ * adds a `fields` array listing the dot/bracket-notation paths that changed.
+ *
+ * Returns `null` when either string cannot be parsed as a JSON object, or
+ * when no fields differ between the two inputs.
+ *
+ * @param originalStr - The original unsanitized JSON log string.
+ * @param sanitizedStr - The sanitized JSON log string.
+ * @param options - Optional configuration.
+ * @returns A JSON warning log string, or `null` if no warning is needed.
+ *
+ * @example
+ * buildSanitizedWarning(
+ *   '{"level":30,"time":1,"pid":1,"hostname":"x","email":"a@b.com","msg":"hi"}',
+ *   '{"level":30,"time":1,"pid":1,"hostname":"x","email":"**********","msg":"hi"}',
+ * )
+ * // => '{"time":1,"pid":1,"hostname":"x","level":40,"msg":"sensitive data found in log entry","fields":["email"]}'
+ *
+ * @example
+ * // Restrict which fields carry over into the warning
+ * buildSanitizedWarning(originalStr, sanitizedStr, { allowedFields: ['time', 'pid', 'hostname'] })
+ */
+const buildSanitizedWarning = (
+  originalStr: string,
+  sanitizedStr: string,
+  options: BuildSanitizedWarningOptions = {},
+): string | null => {
+  let original: unknown;
+  let sanitized: unknown;
+
+  try {
+    original = JSON.parse(originalStr);
+    sanitized = JSON.parse(sanitizedStr);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObj(original) || !isPlainObj(sanitized)) {
+    return null;
+  }
+
+  const fields = diffSanitizedFields(original, sanitized);
+  if (fields.length === 0) {
+    return null;
+  }
+
+  const changedTopLevelKeys = new Set(fields.map(topLevelKey));
+
+  const { allowedFields } = options;
+  const warning: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(sanitized)) {
+    if (key === 'level' || key === 'msg' || changedTopLevelKeys.has(key)) {
+      continue;
+    }
+    if (allowedFields === undefined || allowedFields.includes(key)) {
+      warning[key] = value;
+    }
+  }
+
+  warning.level = WARN_LEVEL;
+  warning.msg = WARN_MSG;
+  warning.fields = fields;
+
+  return JSON.stringify(warning);
+};
+
+export { diffSanitizedFields, buildSanitizedWarning };

--- a/packages/data-sanitization/test/utils.test.ts
+++ b/packages/data-sanitization/test/utils.test.ts
@@ -1,0 +1,491 @@
+/* npm imports */
+import { describe, expect, it } from 'vitest';
+
+/* local imports */
+import { diffSanitizedFields, buildSanitizedWarning } from '../src/utils';
+
+describe('DataSanitizationUtils', () => {
+  describe('diffSanitizedFields', () => {
+    it('should return empty array when objects are identical', () => {
+      // Arrange
+      const original = { level: 30, msg: 'hi' };
+      const sanitized = { level: 30, msg: 'hi' };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    it('should return top-level changed key', () => {
+      // Arrange
+      const original = { email: 'a@b.com', msg: 'hi' };
+      const sanitized = { email: '**********', msg: 'hi' };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['email']);
+    });
+
+    it('should return dot-notation path for nested changed key', () => {
+      // Arrange
+      const original = { msg: 'hi', user: { email: 'a@b.com' } };
+      const sanitized = { msg: 'hi', user: { email: '**********' } };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['user.email']);
+    });
+
+    it('should return bracket-notation paths for changed array elements', () => {
+      // Arrange
+      const original = { tokens: ['abc', 'def'] };
+      const sanitized = { tokens: ['**********', '**********'] };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['tokens[0]', 'tokens[1]']);
+    });
+
+    it('should return bracket-notation path for nested field inside array element', () => {
+      // Arrange
+      const original = { users: [{ email: 'a@b.com', name: 'Alice' }] };
+      const sanitized = { users: [{ email: '**********', name: 'Alice' }] };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['users[0].email']);
+    });
+
+    it('should include path when key is present in original but absent in sanitized', () => {
+      // Arrange
+      const original = { password: 'secret', username: 'mark' };
+      const sanitized = { username: 'mark' };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['password']);
+    });
+
+    it('should include bracket path for array element removed from sanitized', () => {
+      // Arrange
+      const original = { tokens: ['abc', 'def'] };
+      const sanitized = { tokens: [] };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['tokens[0]', 'tokens[1]']);
+    });
+
+    it('should report path when one side is an array and the other is a primitive', () => {
+      // Arrange
+      const original = { data: ['a', 'b'] };
+      const sanitized = { data: '**********' };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['data']);
+    });
+
+    it('should report path when one side is an object and the other is a primitive', () => {
+      // Arrange
+      const original = { user: { email: 'a@b.com' } };
+      const sanitized = { user: '**********' };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['user']);
+    });
+
+    it('should report path when one side is null and the other is an object', () => {
+      // Arrange
+      const original = { meta: { key: 'val' } };
+      const sanitized = { meta: null };
+
+      // Act
+      const result = diffSanitizedFields(
+        original as object,
+        sanitized as object,
+      );
+
+      // Assert
+      expect(result).toEqual(['meta']);
+    });
+
+    it('should return multiple changed paths', () => {
+      // Arrange
+      const original = { email: 'a@b.com', msg: 'hi', password: 'secret' };
+      const sanitized = {
+        email: '**********',
+        msg: 'hi',
+        password: '**********',
+      };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['email', 'password']);
+    });
+
+    it('should return empty array when both objects are empty', () => {
+      // Act
+      const result = diffSanitizedFields({}, {});
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    it('should handle deeply nested changes', () => {
+      // Arrange
+      const original = { a: { b: { c: { password: 'secret' } } } };
+      const sanitized = { a: { b: { c: { password: '**********' } } } };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['a.b.c.password']);
+    });
+
+    it('should report path when one side is an array and the other is a plain object', () => {
+      // Arrange
+      const original = { data: { foo: 1 } };
+      const sanitized = { data: [1, 2] };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['data']);
+    });
+
+    it('should report path when one side is a plain object and the other is an array', () => {
+      // Arrange
+      const original = { data: [1, 2] };
+      const sanitized = { data: { foo: 1 } };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['data']);
+    });
+
+    it('should use bracket-only notation when an array is passed as the root', () => {
+      // Arrange
+      const original = [{ email: 'a@b.com' }] as unknown as object;
+      const sanitized = [{ email: '**********' }] as unknown as object;
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual(['[0].email']);
+    });
+
+    it('should return empty array when root-level array and object differ in type', () => {
+      // Arrange — the diff is one-directional (walks original's keys); when both
+      // roots have no common keys to compare, nothing is reported
+      const original = [] as unknown as object;
+      const sanitized = {} as object;
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    it('should not include keys only present in sanitized', () => {
+      // Arrange
+      const original = { msg: 'hi' };
+      const sanitized = { extra: 'added', msg: 'hi' };
+
+      // Act
+      const result = diffSanitizedFields(original, sanitized);
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('buildSanitizedWarning', () => {
+    it('should return null when originalStr is not valid JSON', () => {
+      // Act
+      const result = buildSanitizedWarning('not json', '{"level":30}');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when sanitizedStr is not valid JSON', () => {
+      // Act
+      const result = buildSanitizedWarning('{"level":30}', 'not json');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when original parses to a non-object (array)', () => {
+      // Act
+      const result = buildSanitizedWarning('[]', '{"level":30}');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when original parses to null', () => {
+      // Act
+      const result = buildSanitizedWarning('null', '{"level":30}');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when sanitized parses to a non-object (array)', () => {
+      // Act
+      const result = buildSanitizedWarning('{"level":30}', '[]');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when sanitized parses to null', () => {
+      // Act
+      const result = buildSanitizedWarning('{"level":30}', 'null');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no fields changed', () => {
+      // Arrange
+      const str = '{"level":30,"msg":"hi","time":1}';
+
+      // Act
+      const result = buildSanitizedWarning(str, str);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return a JSON warning string when a field changed', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"pid":1,"hostname":"x","email":"a@b.com","msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"pid":1,"hostname":"x","email":"**********","msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+
+      // Assert
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+      expect(parsed.level).toBe(40);
+      expect(parsed.msg).toBe('sensitive data found in log entry');
+      expect(parsed.fields).toEqual(['email']);
+    });
+
+    it('should exclude the changed field from the warning entry', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"pid":1,"hostname":"x","email":"a@b.com","msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"pid":1,"hostname":"x","email":"**********","msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed).not.toHaveProperty('email');
+    });
+
+    it('should carry non-changed fields from sanitized into the warning', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"pid":99,"hostname":"host","email":"a@b.com","msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"pid":99,"hostname":"host","email":"**********","msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.time).toBe(1);
+      expect(parsed.pid).toBe(99);
+      expect(parsed.hostname).toBe('host');
+    });
+
+    it('should always override level and msg regardless of their values in the input', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"email":"a@b.com","msg":"original"}';
+      const sanitized =
+        '{"level":30,"time":1,"email":"**********","msg":"original"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.level).toBe(40);
+      expect(parsed.msg).toBe('sensitive data found in log entry');
+    });
+
+    it('should include level and msg in fields when they were themselves sanitized', () => {
+      // Arrange — verifies that level/msg appearing in fields[] is intentional:
+      // the warning body always overrides them anyway, but reporting they changed
+      // is accurate for consumers reading the fields list
+      const original = '{"level":30,"time":1,"msg":"password=secret"}';
+      const sanitized = '{"level":30,"time":1,"msg":"password=**********"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.fields).toContain('msg');
+      expect(parsed.msg).toBe('sensitive data found in log entry');
+    });
+
+    it('should exclude top-level key when a nested field changed', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"user":{"email":"a@b.com","id":1},"msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"user":{"email":"**********","id":1},"msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed).not.toHaveProperty('user');
+      expect(parsed.fields).toEqual(['user.email']);
+    });
+
+    it('should restrict fields to allowedFields when provided', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"pid":99,"hostname":"host","reqId":"abc","email":"a@b.com","msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"pid":99,"hostname":"host","reqId":"abc","email":"**********","msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized, {
+        allowedFields: ['time', 'pid', 'hostname'],
+      });
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.time).toBe(1);
+      expect(parsed.pid).toBe(99);
+      expect(parsed.hostname).toBe('host');
+      expect(parsed).not.toHaveProperty('reqId');
+      expect(parsed).not.toHaveProperty('email');
+    });
+
+    it('should include only allowedFields that are not changed', () => {
+      // Arrange — allowedFields includes the changed field; changed fields are
+      // always excluded regardless of the allowlist
+      const original = '{"level":30,"time":1,"email":"a@b.com","msg":"hi"}';
+      const sanitized = '{"level":30,"time":1,"email":"**********","msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized, {
+        allowedFields: ['time', 'email'],
+      });
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.time).toBe(1);
+      expect(parsed).not.toHaveProperty('email');
+    });
+
+    it('should handle multiple changed fields', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"email":"a@b.com","password":"secret","msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"email":"**********","password":"**********","msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.fields).toEqual(['email', 'password']);
+      expect(parsed).not.toHaveProperty('email');
+      expect(parsed).not.toHaveProperty('password');
+    });
+
+    it('should handle a removed field (removeMatches case)', () => {
+      // Arrange
+      const original = '{"level":30,"time":1,"email":"a@b.com","msg":"hi"}';
+      const sanitized = '{"level":30,"time":1,"msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.fields).toEqual(['email']);
+      expect(parsed).not.toHaveProperty('email');
+    });
+
+    it('should exclude the top-level key when direct array element values changed', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"tokens":["abc","def"],"msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"tokens":["**********","**********"],"msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.fields).toEqual(['tokens[0]', 'tokens[1]']);
+      expect(parsed).not.toHaveProperty('tokens');
+      expect(parsed.time).toBe(1);
+    });
+
+    it('should exclude the top-level key when a nested array element field changed', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1,"users":[{"email":"a@b.com","id":1}],"msg":"hi"}';
+      const sanitized =
+        '{"level":30,"time":1,"users":[{"email":"**********","id":1}],"msg":"hi"}';
+
+      // Act
+      const result = buildSanitizedWarning(original, sanitized);
+      const parsed = JSON.parse(result as string) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.fields).toEqual(['users[0].email']);
+      expect(parsed).not.toHaveProperty('users');
+      expect(parsed.time).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
# Overview

Adds a `data-sanitization/utils` subpath export with two utility functions useful in log middleware: `diffSanitizedFields` and `buildSanitizedWarning`. These functions were previously only available by inlining them per-project.

## Details

- **`diffSanitizedFields(original, sanitized)`** — recursively diffs two objects and returns dot/bracket-notation paths for any keys whose values changed (`user.email`, `tokens[0]`). Keys present in `original` but absent in `sanitized` are included (covers `removeMatches` behaviour).
- **`buildSanitizedWarning(originalStr, sanitizedStr, options?)`** — parses two JSON log strings, diffs them, and builds a structured warning log entry. Carries all non-changed fields from the sanitized object, overrides `level` to `40` and `msg` to a fixed warning string, and adds a `fields` array of the changed paths. Returns `null` when either string isn't parseable JSON or when no fields changed. Accepts an optional `allowedFields` array so log-providers can restrict which context fields carry over.
- `BuildSanitizedWarningOptions` interface added to `types.ts` (consistent with all other exported types in this package).
- `"./utils"` entry added to the `exports` field in `package.json`; `dist/utils.js` + `dist/utils.d.ts` are produced automatically by the existing `tsc` build.

## Related Tickets and/or Pull Requests

Closes #307
Relates to #309 (log-providers companion package will import from this subpath)

## Checklist

- [x] Tests added or updated
- [x] README and TSDoc updated if the public API changed
- [ ] Breaking changes called out (if any)
- [x] Roadmap item checked off if this PR completes one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities to detect changed fields between original and sanitized logs and produce structured sanitization warnings
  * Added option to control which non-sensitive context fields are preserved in warnings
  * Made the utilities available via a new package export for easier import

* **Documentation**
  * Added usage docs and examples showing how to generate and include sanitization warnings

* **Tests**
  * Added comprehensive tests covering diffs, warning generation, options, and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->