### PR TITLE
feat(309): add data-sanitization-log-providers companion package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,34 @@ jobs:
           COVERAGE_GIST_ID: ${{ vars.COVERAGE_GIST_ID }}
           GIST_SECRET: ${{ secrets.GIST_SECRET }}
         run: yarn workspace data-sanitization node scripts/update-coverage-gist.mjs --package-name data-sanitization
+      - name: Report coverage (data-sanitization-log-providers)
+        if: matrix.node-version == 24
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json
+          working-directory: packages/data-sanitization-log-providers
+      - name: Extract coverage percentage (data-sanitization-log-providers)
+        id: coverage-log-providers
+        if: matrix.node-version == 24 && github.event_name == 'push'
+        run: echo "percentage=$(jq '.total.lines.pct' packages/data-sanitization-log-providers/coverage/coverage-summary.json)" >> "$GITHUB_OUTPUT"
+      - name: Update coverage badge (data-sanitization-log-providers)
+        if: matrix.node-version == 24 && github.event_name == 'push'
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: data-sanitization-log-providers-coverage-badge-config.json
+          label: coverage
+          message: ${{ steps.coverage-log-providers.outputs.percentage }}%
+          valColorRange: ${{ steps.coverage-log-providers.outputs.percentage }}
+          maxColorRange: 100
+          minColorRange: 0
+      - name: Update coverage report in Gist (data-sanitization-log-providers)
+        if: matrix.node-version == 24 && github.event_name == 'push'
+        env:
+          COVERAGE_GIST_ID: ${{ vars.COVERAGE_GIST_ID }}
+          GIST_SECRET: ${{ secrets.GIST_SECRET }}
+        run: |
+          cd packages/data-sanitization-log-providers
+          node ../data-sanitization/scripts/update-coverage-gist.mjs --package-name data-sanitization-log-providers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn format:check
       - run: yarn lint:ci
+      - run: yarn build
       - run: yarn test:coverage
       - name: Report coverage (data-sanitization)
         if: matrix.node-version == 24

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,11 +1,8 @@
-approvedGitRepositories:
-  - '**'
-
 enableScripts: true
 
 nodeLinker: pnp
 
-npmMinimalAgeGate: 0
+npmMinimalAgeGate: 10
 
 packageExtensions:
   '@commitlint/cli@*':

--- a/docs/plans/014-log-providers-package.md
+++ b/docs/plans/014-log-providers-package.md
@@ -1,0 +1,161 @@
+# Log Providers Package
+
+## Approach
+
+Add a new `data-sanitization-log-providers` workspace package that ships pre-built adapters
+for pino and winston. Each adapter wires `sanitizeData` into the logger's native hook or
+transport API so consumers don't have to write the glue themselves. The package depends on
+`data-sanitization` as a peer and exposes three subpath exports: `/pino-hook` (the pino
+`streamWrite` hook), `/pino-transport` (a `pino-abstract-transport` worker module), and
+`/winston` (a `TransportStream` subclass). Pino's worker-thread transport model requires the
+`.default` export to be the transport factory, so pino-hook and pino-transport are separate
+subpaths rather than combined into one dual-purpose module.
+
+## Pre-implementation
+
+- Branch `worktree-feat+309-log-providers` created via worktree.
+- Issues #307 (`/utils` subpath) and #308 (monorepo migration) have landed — prerequisites
+  satisfied.
+
+## Steps
+
+1. **`packages/data-sanitization-log-providers/package.json`** — New package manifest.
+   `pino`, `winston`, `pino-abstract-transport`, and `data-sanitization` as peer deps;
+   workspace-protocol dev deps for those same packages plus tooling. Subpath exports for
+   `/pino-hook`, `/pino-transport`, and `/winston`.
+
+2. **`packages/data-sanitization-log-providers/tsconfig.json`** — Package-level tsconfig,
+   mirrors the sibling; extends root `../../tsconfig.json`.
+
+3. **`packages/data-sanitization-log-providers/tsconfig.build.json`** — Build tsconfig that
+   emits to `dist/`; mirrors the sibling.
+
+4. **`packages/data-sanitization-log-providers/vitest.config.ts`** — 100% coverage thresholds;
+   excludes `src/types.ts` from coverage.
+
+5. **`packages/data-sanitization-log-providers/src/types.ts`** — `PinoHookOptions` (extends
+   `DataSanitizationReplacerOptions`, adds `allowedFields` and `onError`);
+   `PinoTransportOptions` (same but omits `customMatchers`, which cannot be serialized over
+   the worker-thread boundary); `WinstonSanitizationOptions` (extends
+   `TransportStreamOptions`, adds `sanitize`, `allowedFields`, `emitWarning`, `onError`).
+
+6. **`packages/data-sanitization-log-providers/src/shared.ts`** — `sanitizeLine` helper used
+   by both pino adapters: sanitizes a string log line and returns the sanitized string plus
+   an optional warning line. Extracts shared logic so pino-hook and pino-transport test the
+   same code path.
+
+7. **`packages/data-sanitization-log-providers/src/pino-hook.ts`** — Exports
+   `createSanitizeLogLine(options?)`. Returns a `(s: string) => string` function suitable for
+   `pino({ hooks: { streamWrite: ... } })`. On error, invokes `options.onError`; default
+   handler emits an error-level (50) JSON placeholder preserving `time`, `pid`, and
+   `hostname` for traceability. Default `allowedFields`: `['time', 'pid', 'hostname']`.
+
+8. **`packages/data-sanitization-log-providers/src/pino-transport.ts`** — Default export is
+   the async `pino-abstract-transport` factory. Accepts `PinoTransportOptions` via
+   `workerData`. Does not accept `customMatchers` (functions are not serializable across the
+   worker-thread boundary). Default `allowedFields`: `['time', 'pid', 'hostname']`.
+
+9. **`packages/data-sanitization-log-providers/src/winston.ts`** — Exports
+   `createSanitizingTransport(options?)` and `SanitizingTransport`. The class extends
+   `TransportStream`, overrides `log(info, callback)`, sanitizes `info[Symbol.for('message')]`,
+   and writes to `process.stdout` (or `options.stream`). Warning line emission is opt-in via
+   `emitWarning: true`; when enabled, both warning and sanitized lines are written as separate
+   `stream.write()` calls. Default `allowedFields`: `[]` (winston has no standardized
+   correlation-field convention; callers opt in explicitly). Documentation explains that the
+   1-to-1 winston format limitation makes the warning line non-trivial to emit from a format
+   transform, which is why this package provides a `TransportStream` subclass instead.
+
+10. **`packages/data-sanitization-log-providers/test/shared.test.ts`** — Tests for the shared
+    sanitization helper.
+
+11. **`packages/data-sanitization-log-providers/test/pino-hook.test.ts`** — Tests for
+    `createSanitizeLogLine`: no-op fast path, sanitization, warning emission, error handling,
+    custom `onError`, `allowedFields` override.
+
+12. **`packages/data-sanitization-log-providers/test/pino-transport.test.ts`** — Tests for the
+    transport default export: calls `build()` from `pino-abstract-transport` with the correct
+    options; verifies the async source handler sanitizes lines correctly using a mock source
+    iterable.
+
+13. **`packages/data-sanitization-log-providers/test/winston.test.ts`** — Tests for
+    `SanitizingTransport`: no-op, sanitization, `emitWarning` on/off, error handling, custom
+    `onError`, `allowedFields`.
+
+14. **`packages/data-sanitization-log-providers/README.md`** — Usage examples for all three
+    adapters; explains `emitWarning` limitation for winston; notes `customMatchers` limitation
+    for the pino transport.
+
+15. **`packages/data-sanitization-log-providers/LICENSE`** — Copy of the MIT license from the
+    sibling package.
+
+16. **`.github/workflows/ci.yml`** — Add a separate coverage reporting block for
+    `data-sanitization-log-providers` alongside the existing `data-sanitization` block.
+
+17. **`docs/ROADMAP.md`** — Mark the log-providers item done once the PR is merged.
+
+## Relevant Files
+
+- `packages/data-sanitization-log-providers/package.json` — new
+- `packages/data-sanitization-log-providers/tsconfig.json` — new
+- `packages/data-sanitization-log-providers/tsconfig.build.json` — new
+- `packages/data-sanitization-log-providers/vitest.config.ts` — new
+- `packages/data-sanitization-log-providers/src/types.ts` — new
+- `packages/data-sanitization-log-providers/src/shared.ts` — new
+- `packages/data-sanitization-log-providers/src/pino-hook.ts` — new
+- `packages/data-sanitization-log-providers/src/pino-transport.ts` — new
+- `packages/data-sanitization-log-providers/src/winston.ts` — new
+- `packages/data-sanitization-log-providers/test/shared.test.ts` — new
+- `packages/data-sanitization-log-providers/test/pino-hook.test.ts` — new
+- `packages/data-sanitization-log-providers/test/pino-transport.test.ts` — new
+- `packages/data-sanitization-log-providers/test/winston.test.ts` — new
+- `packages/data-sanitization-log-providers/README.md` — new
+- `packages/data-sanitization-log-providers/LICENSE` — new
+- `.github/workflows/ci.yml` — updated (add log-providers coverage steps)
+- `docs/ROADMAP.md` — updated (mark item done)
+
+## Verification
+
+```bash
+yarn install
+yarn workspace data-sanitization-log-providers build
+yarn workspace data-sanitization-log-providers test:coverage
+yarn lint:ci
+yarn format:check
+```
+
+All coverage thresholds must pass at 100%. No TypeScript errors. Lint clean.
+
+## Decisions
+
+**Separate `/pino-hook` and `/pino-transport` subpaths rather than a single `/pino`.**
+Pino's worker loader resolves a transport by importing the module and unwrapping `.default`
+twice. A dual-purpose module that exported both a named hook factory and a default transport
+function from one file would work mechanically, but no current pino ecosystem package follows
+this as a deliberate design. Separate subpaths make the intent explicit: `/pino-hook` is for
+main-thread use, `/pino-transport` is a worker module. Users who want only the hook don't pay
+for the `pino-abstract-transport` import.
+
+**`customMatchers` excluded from `PinoTransportOptions`.**
+Transport options are passed via `workerData`, which is structured-cloned across the
+worker-thread boundary. Functions cannot be cloned. Omitting `customMatchers` prevents a
+confusing silent failure. Users who need custom matchers must use the hook adapter instead,
+which runs in the main thread.
+
+**`allowedFields` defaults: `['time', 'pid', 'hostname']` for pino, `[]` for winston.**
+Pino has a standardized core field set (`time`, `pid`, `hostname`) that is always present and
+safe to include in a warning entry for log-aggregation correlation. Winston has no such
+standard; defaults to empty so nothing leaks without an explicit opt-in.
+
+**`emitWarning` opt-in for winston (default `false`) with documentation.**
+Winston formats are 1-to-1 (one `info` object → one serialized `MESSAGE` string). There is no
+built-in mechanism for a format to emit a second log line. The `SanitizingTransport` class
+writes directly to a stream, giving it the ability to call `stream.write()` twice. However,
+two consecutive JSON lines in a single `write` boundary may cause issues with structured log
+aggregators that expect exactly one JSON object per write. The option is exposed with
+documentation rather than hidden or silently broken.
+
+**`SanitizingTransport` writes to `process.stdout` (or `options.stream`) directly.**
+This follows the pattern of winston's built-in `Console` transport. Users who need file or
+external-service output compose this transport with their existing pipeline or pass a custom
+`stream`. A format-based alternative would be more composable but cannot emit the warning
+line, which is the key differentiator this package provides.

--- a/packages/data-sanitization-log-providers/LICENSE
+++ b/packages/data-sanitization-log-providers/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Mark Jubenville
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/data-sanitization-log-providers/README.md
+++ b/packages/data-sanitization-log-providers/README.md
@@ -1,0 +1,138 @@
+# data-sanitization-log-providers
+
+Pre-built log provider adapters for [`data-sanitization`](https://github.com/ioncache/data-sanitization).
+Each adapter wires `sanitizeData` into the logger's native hook or transport API so you don't
+have to write the glue yourself.
+
+## Installation
+
+```bash
+npm install data-sanitization data-sanitization-log-providers
+```
+
+npm is used as an example — yarn, pnpm, and bun work the same way.
+
+Install only the peer dependency for the logger you use:
+
+```bash
+npm install pino                          # for /pino-hook
+npm install pino pino-abstract-transport  # for /pino-transport
+npm install winston                       # for /winston
+```
+
+## Pino — stream write hook (`/pino-hook`)
+
+Runs synchronously in the main thread. Sanitizes each log line and optionally prepends a
+structured warning entry when sensitive fields are found.
+
+```typescript
+import pino from 'pino';
+import { createSanitizeLogLine } from 'data-sanitization-log-providers/pino-hook';
+
+const logger = pino({
+  hooks: {
+    streamWrite: createSanitizeLogLine({
+      // Any DataSanitizationReplacerOptions:
+      customPatterns: ['email', 'health_card'],
+      // Fields to carry into the warning entry (default: ['time', 'pid', 'hostname']):
+      allowedFields: ['time', 'pid', 'hostname'],
+    }),
+  },
+});
+```
+
+The hook function signature is `(s: string) => string`, matching pino's `hooks.streamWrite`
+contract. When a field is sanitized, a `level: 40` warning line is prepended:
+
+```json
+{"time":1716667200000,"pid":1234,"hostname":"api-1","level":40,"msg":"sensitive data found in log entry","fields":["password"]}
+{"time":1716667200000,"pid":1234,"hostname":"api-1","level":30,"msg":"user login","password":"**********"}
+```
+
+### Error handling
+
+When `sanitizeData` throws, the default behaviour is to emit an error-level (50) JSON
+placeholder preserving `time`, `pid`, and `hostname` — the original line is not emitted.
+Override this with `onError`:
+
+```typescript
+createSanitizeLogLine({
+  onError: (err, original) => {
+    myErrorTracker.capture(err);
+    return '{"level":50,"msg":"sanitization failed"}\n';
+  },
+});
+```
+
+## Pino — worker thread transport (`/pino-transport`)
+
+Runs in a `pino.transport()` worker thread via `pino-abstract-transport`. Use this when you
+want process isolation or need to fan out to multiple destinations.
+
+```typescript
+import pino from 'pino';
+
+const logger = pino({
+  transport: {
+    target: 'data-sanitization-log-providers/pino-transport',
+    options: {
+      customPatterns: ['email'],
+      allowedFields: ['time', 'pid', 'hostname'],
+    },
+  },
+});
+```
+
+**Note:** `customMatchers` (custom matcher functions) is not supported via the transport
+because functions cannot be serialized across the worker-thread boundary. Use the
+`/pino-hook` adapter when custom matcher functions are required.
+
+## Winston (`/winston`)
+
+A `TransportStream` subclass that sanitizes each log entry before writing. Compose it with
+`winston.format.json()` (or equivalent) so that `info[Symbol.for('message')]` is populated
+before the transport runs.
+
+```typescript
+import winston from 'winston';
+import { createSanitizingTransport } from 'data-sanitization-log-providers/winston';
+
+const logger = winston.createLogger({
+  format: winston.format.json(),
+  transports: [
+    createSanitizingTransport({
+      sanitize: { customPatterns: ['email'] },
+    }),
+  ],
+});
+```
+
+### Warning lines (`emitWarning`)
+
+The `emitWarning` option is disabled by default. When enabled, a structured warning entry is
+written to the output stream immediately before the sanitized line:
+
+```typescript
+createSanitizingTransport({
+  emitWarning: true,
+  allowedFields: ['timestamp', 'service'],
+});
+```
+
+**Why `emitWarning` is opt-in:** Winston formats are 1-to-1 — one `info` object produces one
+serialized `MESSAGE` string. There is no built-in way to emit a second log line from a format
+transform. This transport subclass owns the write path directly, which makes the two-line
+pattern possible. However, structured log aggregators that expect exactly one JSON object per
+write call may not handle the extra line correctly. Enable this option only when writing to a
+file or stream where embedded newlines are safe.
+
+### Error handling (`onError`)
+
+When `sanitizeData` throws, an error-level placeholder is written in place of the original
+line. Provide `onError` to be notified:
+
+```typescript
+createSanitizingTransport({
+  onError: (err) => myErrorTracker.capture(err),
+});
+```

--- a/packages/data-sanitization-log-providers/package.json
+++ b/packages/data-sanitization-log-providers/package.json
@@ -1,23 +1,19 @@
 {
-  "name": "data-sanitization",
-  "version": "1.4.1",
-  "description": "Sanitization library for masking or removing sensitive data.",
+  "name": "data-sanitization-log-providers",
+  "version": "1.0.0",
+  "description": "Pre-built log provider adapters for data-sanitization (pino, winston).",
   "keywords": [
     "data-sanitization",
     "logging",
-    "mask",
-    "masking",
-    "phi",
-    "pii",
+    "pino",
     "redact",
-    "redaction",
     "sanitization",
     "sanitize",
-    "secrets",
     "sensitive-data",
-    "typescript"
+    "typescript",
+    "winston"
   ],
-  "homepage": "https://github.com/ioncache/data-sanitization#readme",
+  "homepage": "https://github.com/ioncache/data-sanitization/tree/main/packages/data-sanitization-log-providers",
   "bugs": {
     "url": "https://github.com/ioncache/data-sanitization/issues"
   },
@@ -29,27 +25,27 @@
   },
   "files": [
     "dist",
-    "docs/performance.md",
     "README.md",
     "LICENSE"
   ],
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "./pino-hook": {
+      "types": "./dist/pino-hook.d.ts",
+      "default": "./dist/pino-hook.js"
     },
-    "./utils": {
-      "types": "./dist/utils.d.ts",
-      "default": "./dist/utils.js"
+    "./pino-transport": {
+      "types": "./dist/pino-transport.d.ts",
+      "default": "./dist/pino-transport.js"
+    },
+    "./winston": {
+      "types": "./dist/winston.d.ts",
+      "default": "./dist/winston.js"
     }
   },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "bench": "vitest bench",
     "build": "yarn clean && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist coverage && find . -maxdepth 1 -name '*.tsbuildinfo' -delete",
     "format": "oxfmt",
@@ -64,12 +60,32 @@
   "devDependencies": {
     "@types/node": "^25.9.0",
     "@vitest/coverage-v8": "^4.1.6",
+    "data-sanitization": "workspace:*",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.66.0",
-    "query-string": "^9.3.1",
+    "pino": "^9.0.0",
+    "pino-abstract-transport": "^2.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6",
-    "yargs": "^18.0.0"
+    "winston": "^3.19.0",
+    "winston-transport": "^4.9.0"
+  },
+  "peerDependencies": {
+    "data-sanitization": ">=1.5.0",
+    "pino": ">=9.0.0",
+    "pino-abstract-transport": ">=2.0.0",
+    "winston": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "pino": {
+      "optional": true
+    },
+    "pino-abstract-transport": {
+      "optional": true
+    },
+    "winston": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22.22.1"

--- a/packages/data-sanitization-log-providers/src/pino-hook.ts
+++ b/packages/data-sanitization-log-providers/src/pino-hook.ts
@@ -1,0 +1,56 @@
+import {
+  buildErrorPlaceholder,
+  PINO_DEFAULT_ALLOWED_FIELDS,
+  sanitizeLine,
+} from './shared.js';
+import type { PinoHookOptions } from './types.js';
+
+/**
+ * Creates a sanitizing function for pino's `hooks.streamWrite` option.
+ *
+ * The returned function sanitizes each log line synchronously in the main
+ * thread. When sensitive fields are found, a structured warning entry is
+ * prepended so the sanitization event is visible in log aggregators. On
+ * error, the default handler emits an error-level (50) JSON placeholder
+ * preserving `time`, `pid`, and `hostname` for traceability.
+ *
+ * @param options - Sanitization and hook options.
+ * @returns A `(s: string) => string` function for `pino({ hooks: { streamWrite: fn } })`.
+ *
+ * @example
+ * import pino from 'pino';
+ * import { createSanitizeLogLine } from 'data-sanitization-log-providers/pino-hook';
+ *
+ * const logger = pino({
+ *   hooks: { streamWrite: createSanitizeLogLine({ customPatterns: ['email'] }) },
+ * });
+ */
+function createSanitizeLogLine(
+  options: PinoHookOptions = {},
+): (s: string) => string {
+  const {
+    onError,
+    allowedFields = PINO_DEFAULT_ALLOWED_FIELDS,
+    ...sanitizeOptions
+  } = options;
+
+  return function sanitizeLogLine(s: string): string {
+    let result: ReturnType<typeof sanitizeLine>;
+    try {
+      result = sanitizeLine(s, sanitizeOptions, allowedFields);
+    } catch (err) {
+      if (onError) {
+        return onError(err, s);
+      }
+      return buildErrorPlaceholder(s) + '\n';
+    }
+
+    const { sanitized, warning } = result;
+    if (warning) {
+      return warning + '\n' + sanitized;
+    }
+    return sanitized;
+  };
+}
+
+export { createSanitizeLogLine };

--- a/packages/data-sanitization-log-providers/src/pino-transport.ts
+++ b/packages/data-sanitization-log-providers/src/pino-transport.ts
@@ -1,0 +1,60 @@
+import build from 'pino-abstract-transport';
+import {
+  buildErrorPlaceholder,
+  PINO_DEFAULT_ALLOWED_FIELDS,
+  sanitizeLine,
+} from './shared.js';
+import type { PinoTransportOptions } from './types.js';
+
+/**
+ * Pino `pino-abstract-transport` worker module.
+ *
+ * Use as the `target` for `pino.transport()`. Sanitizes each log line and
+ * writes the result to `process.stdout`. When sensitive fields are found, a
+ * structured warning entry is written first so the sanitization event is
+ * visible in log aggregators. On error, an error-level (50) JSON placeholder
+ * is written in place of the original line.
+ *
+ * Note: `customMatchers` is not supported because functions cannot be
+ * serialized across the worker-thread boundary. Use the `/pino-hook` adapter
+ * when custom matcher functions are required.
+ *
+ * @param opts - Serializable sanitization options passed via `pino.transport({ options: ... })`.
+ *
+ * @example
+ * import pino from 'pino';
+ *
+ * const logger = pino({
+ *   transport: {
+ *     target: 'data-sanitization-log-providers/pino-transport',
+ *     options: { customPatterns: ['email'] },
+ *   },
+ * });
+ */
+export default async function pinoTransport(
+  opts: PinoTransportOptions = {},
+): Promise<unknown> {
+  const { allowedFields = PINO_DEFAULT_ALLOWED_FIELDS, ...sanitizeOptions } =
+    opts;
+
+  return build(
+    async function (source: AsyncIterable<string>): Promise<void> {
+      for await (const line of source) {
+        try {
+          const { sanitized, warning } = sanitizeLine(
+            line,
+            sanitizeOptions,
+            allowedFields,
+          );
+          if (warning) {
+            process.stdout.write(warning + '\n');
+          }
+          process.stdout.write(sanitized + '\n');
+        } catch {
+          process.stdout.write(buildErrorPlaceholder(line) + '\n');
+        }
+      }
+    },
+    { parse: 'lines' },
+  );
+}

--- a/packages/data-sanitization-log-providers/src/pino-transport.ts
+++ b/packages/data-sanitization-log-providers/src/pino-transport.ts
@@ -1,4 +1,11 @@
+import { once } from 'node:events';
 import build from 'pino-abstract-transport';
+
+const writeLine = async (line: string): Promise<void> => {
+  if (!process.stdout.write(line + '\n')) {
+    await once(process.stdout, 'drain');
+  }
+};
 import {
   buildErrorPlaceholder,
   PINO_DEFAULT_ALLOWED_FIELDS,
@@ -47,11 +54,11 @@ export default async function pinoTransport(
             allowedFields,
           );
           if (warning) {
-            process.stdout.write(warning + '\n');
+            await writeLine(warning);
           }
-          process.stdout.write(sanitized + '\n');
+          await writeLine(sanitized);
         } catch {
-          process.stdout.write(buildErrorPlaceholder(line) + '\n');
+          await writeLine(buildErrorPlaceholder(line));
         }
       }
     },

--- a/packages/data-sanitization-log-providers/src/shared.ts
+++ b/packages/data-sanitization-log-providers/src/shared.ts
@@ -6,7 +6,11 @@ import { buildSanitizedWarning } from 'data-sanitization/utils';
 
 const ERROR_LEVEL = 50;
 const ERROR_MSG = 'log entry dropped: sanitization failed';
-const PINO_DEFAULT_ALLOWED_FIELDS = ['time', 'pid', 'hostname'];
+const PINO_DEFAULT_ALLOWED_FIELDS = Object.freeze([
+  'time',
+  'pid',
+  'hostname',
+] as const);
 
 interface SanitizeLineResult {
   sanitized: string;
@@ -25,7 +29,7 @@ interface SanitizeLineResult {
 function sanitizeLine(
   line: string,
   sanitizeOptions: DataSanitizationReplacerOptions,
-  allowedFields: string[],
+  allowedFields: readonly string[],
 ): SanitizeLineResult {
   const sanitized = sanitizeData(line, sanitizeOptions) as string;
   const warning =

--- a/packages/data-sanitization-log-providers/src/shared.ts
+++ b/packages/data-sanitization-log-providers/src/shared.ts
@@ -1,0 +1,64 @@
+import {
+  sanitizeData,
+  type DataSanitizationReplacerOptions,
+} from 'data-sanitization';
+import { buildSanitizedWarning } from 'data-sanitization/utils';
+
+const ERROR_LEVEL = 50;
+const ERROR_MSG = 'log entry dropped: sanitization failed';
+const PINO_DEFAULT_ALLOWED_FIELDS = ['time', 'pid', 'hostname'];
+
+interface SanitizeLineResult {
+  sanitized: string;
+  warning: string | null;
+}
+
+/**
+ * Sanitizes a JSON log line and returns the sanitized string plus an optional
+ * warning line.
+ *
+ * @param line - Raw log line to sanitize (with or without trailing newline).
+ * @param sanitizeOptions - Options forwarded to `sanitizeData`.
+ * @param allowedFields - Fields to carry into the warning entry.
+ * @returns Object with `sanitized` and `warning` (`null` when no fields changed).
+ */
+function sanitizeLine(
+  line: string,
+  sanitizeOptions: DataSanitizationReplacerOptions,
+  allowedFields: string[],
+): SanitizeLineResult {
+  const sanitized = sanitizeData(line, sanitizeOptions) as string;
+  const warning =
+    sanitized !== line
+      ? buildSanitizedWarning(line, sanitized, { allowedFields })
+      : null;
+  return { sanitized, warning };
+}
+
+/**
+ * Builds a JSON error-level placeholder from a raw log line, preserving
+ * `time`, `pid`, and `hostname` for traceability without re-emitting
+ * potentially unsanitized content.
+ *
+ * @param original - Original log line before sanitization.
+ * @returns A JSON string at level 50 indicating sanitization failure.
+ */
+function buildErrorPlaceholder(original: string): string {
+  try {
+    const parsed = JSON.parse(original) as Record<string, unknown>;
+    const { time, pid, hostname } = parsed;
+    return JSON.stringify({
+      level: ERROR_LEVEL,
+      ...(time !== undefined && { time }),
+      ...(pid !== undefined && { pid }),
+      ...(hostname !== undefined && { hostname }),
+      msg: ERROR_MSG,
+    });
+  } catch {
+    /* istanbul ignore next -- only reached when original is not valid JSON */
+    return JSON.stringify({ level: ERROR_LEVEL, msg: ERROR_MSG });
+  }
+}
+
+export { sanitizeLine, buildErrorPlaceholder, PINO_DEFAULT_ALLOWED_FIELDS };
+export type { SanitizeLineResult };

--- a/packages/data-sanitization-log-providers/src/types.ts
+++ b/packages/data-sanitization-log-providers/src/types.ts
@@ -1,0 +1,90 @@
+import type { DataSanitizationReplacerOptions } from 'data-sanitization';
+
+/**
+ * Options for {@link createSanitizeLogLine}.
+ */
+interface PinoHookOptions extends DataSanitizationReplacerOptions {
+  /**
+   * Fields from the sanitized log object to carry into the warning entry.
+   *
+   * Default: `['time', 'pid', 'hostname']`.
+   */
+  allowedFields?: string[];
+  /**
+   * Called when `sanitizeData` throws. Must return a string to write in place
+   * of the original log line. Default: emits an error-level (50) JSON
+   * placeholder preserving `time`, `pid`, and `hostname` from the original.
+   */
+  onError?: (err: unknown, original: string) => string;
+}
+
+/**
+ * Options for the pino transport default export.
+ *
+ * Extends {@link DataSanitizationReplacerOptions} except for `customMatchers`,
+ * which cannot be serialized across the worker-thread boundary. Use the
+ * `/pino-hook` adapter when custom matcher functions are required.
+ */
+type PinoTransportOptions = Omit<
+  DataSanitizationReplacerOptions,
+  'customMatchers'
+> & {
+  /**
+   * Fields from the sanitized log object to carry into the warning entry.
+   *
+   * Default: `['time', 'pid', 'hostname']`.
+   */
+  allowedFields?: string[];
+};
+
+/**
+ * Options for {@link createSanitizingTransport}.
+ */
+interface WinstonSanitizationOptions {
+  /** Standard winston transport options (level, silent, handleExceptions). */
+  level?: string;
+  silent?: boolean;
+  handleExceptions?: boolean;
+  handleRejections?: boolean;
+  /**
+   * Sanitization options forwarded to `sanitizeData`.
+   */
+  sanitize?: DataSanitizationReplacerOptions;
+  /**
+   * Fields from the sanitized log object to carry into the warning entry.
+   *
+   * Default: `[]` — no fields carry through unless explicitly listed. Winston
+   * has no standardized correlation-field convention, so callers opt in
+   * explicitly (e.g. `['timestamp', 'service']`).
+   */
+  allowedFields?: string[];
+  /**
+   * When `true`, a structured warning line is written to the output stream
+   * immediately before the sanitized line as a separate `stream.write()` call.
+   *
+   * Winston formats are 1-to-1 (one `info` object → one serialized `MESSAGE`
+   * string), so there is no built-in way to emit a second log line from a
+   * format transform. This transport subclass owns the write path, which makes
+   * the two-line pattern possible. Enable only when writing to a file or
+   * stream — structured aggregators that expect exactly one JSON object per
+   * write call may not handle the extra line correctly.
+   *
+   * Default: `false`.
+   */
+  emitWarning?: boolean;
+  /**
+   * Output stream. Default: `process.stdout`.
+   */
+  stream?: NodeJS.WritableStream;
+  /**
+   * Called when `sanitizeData` throws. Default: emits an error-level
+   * placeholder to the output stream and continues processing.
+   */
+  onError?: (err: unknown) => void;
+}
+
+export type {
+  PinoHookOptions,
+  PinoTransportOptions,
+  WinstonSanitizationOptions,
+};

--- a/packages/data-sanitization-log-providers/src/types.ts
+++ b/packages/data-sanitization-log-providers/src/types.ts
@@ -9,7 +9,7 @@ interface PinoHookOptions extends DataSanitizationReplacerOptions {
    *
    * Default: `['time', 'pid', 'hostname']`.
    */
-  allowedFields?: string[];
+  allowedFields?: readonly string[];
   /**
    * Called when `sanitizeData` throws. Must return a string to write in place
    * of the original log line. Default: emits an error-level (50) JSON
@@ -34,7 +34,7 @@ type PinoTransportOptions = Omit<
    *
    * Default: `['time', 'pid', 'hostname']`.
    */
-  allowedFields?: string[];
+  allowedFields?: readonly string[];
 };
 
 /**
@@ -57,7 +57,7 @@ interface WinstonSanitizationOptions {
    * has no standardized correlation-field convention, so callers opt in
    * explicitly (e.g. `['timestamp', 'service']`).
    */
-  allowedFields?: string[];
+  allowedFields?: readonly string[];
   /**
    * When `true`, a structured warning line is written to the output stream
    * immediately before the sanitized line as a separate `stream.write()` call.

--- a/packages/data-sanitization-log-providers/src/winston.ts
+++ b/packages/data-sanitization-log-providers/src/winston.ts
@@ -18,7 +18,7 @@ const MESSAGE = Symbol.for('message');
  */
 class SanitizingTransport extends TransportStream {
   readonly #sanitizeOptions: DataSanitizationReplacerOptions;
-  readonly #allowedFields: string[];
+  readonly #allowedFields: readonly string[];
   readonly #emitWarning: boolean;
   readonly #dest: NodeJS.WritableStream;
   readonly #onError: (err: unknown) => void;
@@ -46,25 +46,20 @@ class SanitizingTransport extends TransportStream {
       | string
       | undefined;
 
-    if (typeof raw !== 'string') {
-      this.#dest.write(JSON.stringify(info) + '\n');
-      this.emit('logged', info);
-      callback();
-      return;
-    }
+    const input = typeof raw === 'string' ? raw : JSON.stringify(info);
 
     let sanitized: string;
     let warning: string | null = null;
 
     try {
       ({ sanitized, warning } = sanitizeLine(
-        raw,
+        input,
         this.#sanitizeOptions,
         this.#allowedFields,
       ));
     } catch (err) {
       this.#onError(err);
-      this.#dest.write(buildErrorPlaceholder(raw) + '\n');
+      this.#dest.write(buildErrorPlaceholder(input) + '\n');
       this.emit('logged', info);
       callback();
       return;

--- a/packages/data-sanitization-log-providers/src/winston.ts
+++ b/packages/data-sanitization-log-providers/src/winston.ts
@@ -1,0 +1,113 @@
+import TransportStream from 'winston-transport';
+import { sanitizeLine, buildErrorPlaceholder } from './shared.js';
+import type { DataSanitizationReplacerOptions } from 'data-sanitization';
+import type { WinstonSanitizationOptions } from './types.js';
+
+const MESSAGE = Symbol.for('message');
+
+/**
+ * A winston `TransportStream` that sanitizes log entries before writing them.
+ *
+ * Reads `info[Symbol.for('message')]` (the final serialized string produced by
+ * upstream formats such as `format.json()`), sanitizes it, and writes the
+ * result to the configured output stream. When `emitWarning` is enabled, a
+ * structured warning line is written first as a separate `stream.write()` call.
+ *
+ * Add this transport after a serializing format in the format chain so that
+ * `info[MESSAGE]` is already a JSON string when `log()` is called.
+ */
+class SanitizingTransport extends TransportStream {
+  readonly #sanitizeOptions: DataSanitizationReplacerOptions;
+  readonly #allowedFields: string[];
+  readonly #emitWarning: boolean;
+  readonly #dest: NodeJS.WritableStream;
+  readonly #onError: (err: unknown) => void;
+
+  constructor(opts: WinstonSanitizationOptions = {}) {
+    const {
+      sanitize = {},
+      allowedFields = [],
+      emitWarning = false,
+      stream: dest = process.stdout,
+      onError,
+      ...rest
+    } = opts;
+    super(rest as ConstructorParameters<typeof TransportStream>[0]);
+    this.#sanitizeOptions = sanitize;
+    this.#allowedFields = allowedFields;
+    this.#emitWarning = emitWarning;
+    this.#dest = dest;
+    this.#onError = onError ?? (() => undefined);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override log(info: any, callback: () => void): void {
+    const raw = (info as Record<symbol, unknown>)[MESSAGE] as
+      | string
+      | undefined;
+
+    if (typeof raw !== 'string') {
+      this.#dest.write(JSON.stringify(info) + '\n');
+      this.emit('logged', info);
+      callback();
+      return;
+    }
+
+    let sanitized: string;
+    let warning: string | null = null;
+
+    try {
+      ({ sanitized, warning } = sanitizeLine(
+        raw,
+        this.#sanitizeOptions,
+        this.#allowedFields,
+      ));
+    } catch (err) {
+      this.#onError(err);
+      this.#dest.write(buildErrorPlaceholder(raw) + '\n');
+      this.emit('logged', info);
+      callback();
+      return;
+    }
+
+    if (this.#emitWarning && warning) {
+      this.#dest.write(warning + '\n');
+    }
+    this.#dest.write(sanitized + '\n');
+    this.emit('logged', info);
+    callback();
+  }
+}
+
+/**
+ * Creates a sanitizing winston transport.
+ *
+ * Sanitizes each log entry's serialized `MESSAGE` string before writing it to
+ * the output stream. Compose with `winston.format.json()` (or equivalent) so
+ * that the `MESSAGE` symbol is populated before sanitization runs.
+ *
+ * @param options - Transport and sanitization options.
+ * @returns A configured {@link SanitizingTransport} instance.
+ *
+ * @example
+ * import winston from 'winston';
+ * import { createSanitizingTransport } from 'data-sanitization-log-providers/winston';
+ *
+ * const logger = winston.createLogger({
+ *   format: winston.format.json(),
+ *   transports: [
+ *     createSanitizingTransport({
+ *       sanitize: { customPatterns: ['email'] },
+ *       allowedFields: ['timestamp', 'service'],
+ *       emitWarning: true,
+ *     }),
+ *   ],
+ * });
+ */
+function createSanitizingTransport(
+  options: WinstonSanitizationOptions = {},
+): SanitizingTransport {
+  return new SanitizingTransport(options);
+}
+
+export { createSanitizingTransport, SanitizingTransport };

--- a/packages/data-sanitization-log-providers/src/winston.ts
+++ b/packages/data-sanitization-log-providers/src/winston.ts
@@ -46,12 +46,11 @@ class SanitizingTransport extends TransportStream {
       | string
       | undefined;
 
-    const input = typeof raw === 'string' ? raw : JSON.stringify(info);
-
     let sanitized: string;
     let warning: string | null = null;
 
     try {
+      const input = typeof raw === 'string' ? raw : JSON.stringify(info);
       ({ sanitized, warning } = sanitizeLine(
         input,
         this.#sanitizeOptions,
@@ -59,7 +58,7 @@ class SanitizingTransport extends TransportStream {
       ));
     } catch (err) {
       this.#onError(err);
-      this.#dest.write(buildErrorPlaceholder(input) + '\n');
+      this.#dest.write(buildErrorPlaceholder(raw ?? '') + '\n');
       this.emit('logged', info);
       callback();
       return;

--- a/packages/data-sanitization-log-providers/test/pino-hook.test.ts
+++ b/packages/data-sanitization-log-providers/test/pino-hook.test.ts
@@ -1,0 +1,175 @@
+/* npm imports */
+import { describe, expect, it, vi } from 'vitest';
+
+/* local imports */
+import { createSanitizeLogLine } from '../src/pino-hook';
+
+const clean = '{"level":30,"time":1,"pid":1,"hostname":"h","msg":"hello"}\n';
+const dirty =
+  '{"level":30,"time":1,"pid":1,"hostname":"h","password":"secret","msg":"hi"}\n';
+
+describe('pino-hook', () => {
+  describe('createSanitizeLogLine', () => {
+    it('should return the original line unchanged when no sensitive fields are present', () => {
+      // Arrange
+      const hook = createSanitizeLogLine();
+
+      // Act
+      const result = hook(clean);
+
+      // Assert
+      expect(result).toBe(clean);
+    });
+
+    it('should sanitize a sensitive field and return a masked line', () => {
+      // Arrange
+      const hook = createSanitizeLogLine();
+
+      // Act
+      const result = hook(dirty);
+
+      // Assert
+      expect(result).not.toContain('"secret"');
+      expect(result).toContain('**********');
+    });
+
+    it('should prepend a warning line when a field is sanitized', () => {
+      // Arrange
+      const hook = createSanitizeLogLine();
+
+      // Act
+      const result = hook(dirty);
+      const lines = result.split('\n').filter(Boolean);
+
+      // Assert
+      expect(lines).toHaveLength(2);
+      const warning = JSON.parse(lines[0]) as Record<string, unknown>;
+      expect(warning.level).toBe(40);
+      expect(warning.msg).toBe('sensitive data found in log entry');
+      expect(warning.fields).toEqual(['password']);
+    });
+
+    it('should include default allowedFields (time, pid, hostname) in the warning', () => {
+      // Arrange
+      const hook = createSanitizeLogLine();
+
+      // Act
+      const result = hook(dirty);
+      const warning = JSON.parse(result.split('\n')[0]) as Record<
+        string,
+        unknown
+      >;
+
+      // Assert
+      expect(warning.time).toBe(1);
+      expect(warning.pid).toBe(1);
+      expect(warning.hostname).toBe('h');
+    });
+
+    it('should use custom allowedFields when provided', () => {
+      // Arrange
+      const hook = createSanitizeLogLine({ allowedFields: ['time'] });
+
+      // Act
+      const result = hook(dirty);
+      const warning = JSON.parse(result.split('\n')[0]) as Record<
+        string,
+        unknown
+      >;
+
+      // Assert
+      expect(warning.time).toBe(1);
+      expect(warning).not.toHaveProperty('pid');
+      expect(warning).not.toHaveProperty('hostname');
+    });
+
+    it('should emit no warning when allowedFields is empty and field changed', () => {
+      // Arrange
+      const hook = createSanitizeLogLine({ allowedFields: [] });
+
+      // Act
+      const result = hook(dirty);
+      const lines = result.split('\n').filter(Boolean);
+
+      // Assert — warning is still emitted (fields array always present), just has no extra fields
+      expect(lines).toHaveLength(2);
+      const warning = JSON.parse(lines[0]) as Record<string, unknown>;
+      expect(warning.fields).toEqual(['password']);
+    });
+
+    it('should accept custom sanitization options', () => {
+      // Arrange
+      const line =
+        '{"level":30,"time":1,"email":"mark@example.com","msg":"hi"}\n';
+      const hook = createSanitizeLogLine({ customPatterns: ['email'] });
+
+      // Act
+      const result = hook(line);
+
+      // Assert
+      expect(result).not.toContain('mark@example.com');
+    });
+
+    it('should call onError and return its result when sanitization throws', () => {
+      // Arrange
+      const onError = vi.fn(
+        (_err: unknown, original: string) => 'ERROR:' + original,
+      );
+      const hook = createSanitizeLogLine({
+        customMatchers: [
+          () => {
+            throw new Error('matcher failed');
+          },
+        ],
+        onError,
+      });
+
+      // Act
+      const result = hook(dirty);
+
+      // Assert
+      expect(onError).toHaveBeenCalledOnce();
+      expect(result).toContain('ERROR:');
+    });
+
+    it('should emit an error-level placeholder when sanitization throws and no onError is set', () => {
+      // Arrange
+      const hook = createSanitizeLogLine({
+        customMatchers: [
+          () => {
+            throw new Error('matcher failed');
+          },
+        ],
+      });
+
+      // Act
+      const result = hook(dirty);
+      const parsed = JSON.parse(result.trim()) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.level).toBe(50);
+      expect(parsed.msg).toBe('log entry dropped: sanitization failed');
+      expect(parsed.time).toBe(1);
+      expect(parsed.pid).toBe(1);
+      expect(parsed.hostname).toBe('h');
+    });
+
+    it('should not include sensitive fields in the error placeholder', () => {
+      // Arrange
+      const hook = createSanitizeLogLine({
+        customMatchers: [
+          () => {
+            throw new Error('matcher failed');
+          },
+        ],
+      });
+
+      // Act
+      const result = hook(dirty);
+
+      // Assert
+      expect(result).not.toContain('secret');
+      expect(result).not.toContain('password');
+    });
+  });
+});

--- a/packages/data-sanitization-log-providers/test/pino-transport.test.ts
+++ b/packages/data-sanitization-log-providers/test/pino-transport.test.ts
@@ -161,6 +161,44 @@ describe('pino-transport', () => {
       expect(parsed.msg).toBe('log entry dropped: sanitization failed');
     });
 
+    it('should handle backpressure when write returns false and drain is emitted', async () => {
+      // Arrange
+      const written: string[] = [];
+      let firstCall = true;
+      const writeSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation((chunk) => {
+          written.push(typeof chunk === 'string' ? chunk : String(chunk));
+          if (firstCall) {
+            firstCall = false;
+            setImmediate(() => process.stdout.emit('drain'));
+            return false;
+          }
+          return true;
+        });
+
+      try {
+        await pinoTransport();
+
+        const buildMock = (await import('pino-abstract-transport'))
+          .default as ReturnType<typeof vi.fn>;
+        const [sourceHandler] = buildMock.mock.lastCall as [
+          (source: AsyncIterable<string>) => Promise<void>,
+        ];
+
+        async function* makeSource(): AsyncGenerator<string> {
+          yield clean;
+        }
+
+        await sourceHandler(makeSource());
+      } finally {
+        writeSpy.mockRestore();
+      }
+
+      // Assert — line was written despite backpressure
+      expect(written).toEqual([clean + '\n']);
+    });
+
     it('should pass build the parse:lines option', async () => {
       // Act
       await pinoTransport();

--- a/packages/data-sanitization-log-providers/test/pino-transport.test.ts
+++ b/packages/data-sanitization-log-providers/test/pino-transport.test.ts
@@ -1,0 +1,178 @@
+/* npm imports */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* local imports */
+import pinoTransport from '../src/pino-transport';
+
+const clean = '{"level":30,"time":1,"pid":1,"hostname":"h","msg":"hello"}';
+const dirty =
+  '{"level":30,"time":1,"pid":1,"hostname":"h","password":"secret","msg":"hi"}';
+
+async function runTransport(
+  lines: string[],
+  opts: Parameters<typeof pinoTransport>[0] = {},
+): Promise<string[]> {
+  const written: string[] = [];
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk) => {
+      written.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+
+  try {
+    await pinoTransport(opts);
+
+    // Access the source handler via the build mock
+    const buildMock = (await import('pino-abstract-transport'))
+      .default as ReturnType<typeof vi.fn>;
+    const [sourceHandler] = buildMock.mock.lastCall as [
+      (source: AsyncIterable<string>) => Promise<void>,
+    ];
+
+    async function* makeSource(): AsyncGenerator<string> {
+      for (const line of lines) {
+        yield line;
+      }
+    }
+
+    await sourceHandler(makeSource());
+  } finally {
+    writeSpy.mockRestore();
+  }
+
+  return written;
+}
+
+vi.mock('pino-abstract-transport', () => ({
+  default: vi.fn((fn: unknown, _opts: unknown) => fn),
+}));
+
+describe('pino-transport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('pinoTransport', () => {
+    it('should write the original line unchanged when no sensitive fields are present', async () => {
+      // Act
+      const written = await runTransport([clean]);
+
+      // Assert
+      expect(written).toEqual([clean + '\n']);
+    });
+
+    it('should sanitize a sensitive field', async () => {
+      // Act
+      const written = await runTransport([dirty]);
+
+      // Assert
+      const sanitizedLine = written.find((w) => w.includes('"msg":"hi"'));
+      expect(sanitizedLine).toBeDefined();
+      expect(sanitizedLine).not.toContain('"secret"');
+      expect(sanitizedLine).toContain('**********');
+    });
+
+    it('should write a warning line before the sanitized line', async () => {
+      // Act
+      const written = await runTransport([dirty]);
+
+      // Assert
+      expect(written).toHaveLength(2);
+      const warning = JSON.parse(written[0].trim()) as Record<string, unknown>;
+      expect(warning.level).toBe(40);
+      expect(warning.fields).toEqual(['password']);
+    });
+
+    it('should include default allowedFields (time, pid, hostname) in the warning', async () => {
+      // Act
+      const written = await runTransport([dirty]);
+      const warning = JSON.parse(written[0].trim()) as Record<string, unknown>;
+
+      // Assert
+      expect(warning.time).toBe(1);
+      expect(warning.pid).toBe(1);
+      expect(warning.hostname).toBe('h');
+    });
+
+    it('should use custom allowedFields when provided', async () => {
+      // Act
+      const written = await runTransport([dirty], { allowedFields: ['time'] });
+      const warning = JSON.parse(written[0].trim()) as Record<string, unknown>;
+
+      // Assert
+      expect(warning.time).toBe(1);
+      expect(warning).not.toHaveProperty('pid');
+    });
+
+    it('should handle multiple lines in sequence', async () => {
+      // Act
+      const written = await runTransport([clean, dirty, clean]);
+
+      // Assert — clean+clean write 1 line each, dirty writes 2
+      expect(written).toHaveLength(4);
+    });
+
+    it('should write an error placeholder when sanitization throws', async () => {
+      // Arrange — customPatterns is fine but we need a matcher that throws
+      // Use a custom matcher that throws to force the error path
+      const written: string[] = [];
+      const writeSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation((chunk) => {
+          written.push(typeof chunk === 'string' ? chunk : String(chunk));
+          return true;
+        });
+
+      await pinoTransport();
+
+      const buildMock = (await import('pino-abstract-transport'))
+        .default as ReturnType<typeof vi.fn>;
+      const [sourceHandler] = buildMock.mock.lastCall as [
+        (source: AsyncIterable<string>) => Promise<void>,
+      ];
+
+      // Override sanitizeLine to throw by passing an invalid customMatchers
+      // (functions are not supported in PinoTransportOptions, so we simulate
+      // the error path by using vi.mock on the shared module)
+      const shared = await import('../src/shared');
+      const throwingSanitize = vi
+        .spyOn(shared, 'sanitizeLine')
+        .mockImplementationOnce(() => {
+          throw new Error('sanitization failed');
+        });
+
+      async function* makeSource(): AsyncGenerator<string> {
+        yield dirty;
+      }
+
+      await sourceHandler(makeSource());
+      writeSpy.mockRestore();
+      throwingSanitize.mockRestore();
+
+      // Assert
+      expect(written).toHaveLength(1);
+      const parsed = JSON.parse(written[0].trim()) as Record<string, unknown>;
+      expect(parsed.level).toBe(50);
+      expect(parsed.msg).toBe('log entry dropped: sanitization failed');
+    });
+
+    it('should pass build the parse:lines option', async () => {
+      // Act
+      await pinoTransport();
+
+      // Assert
+      const buildMock = (await import('pino-abstract-transport'))
+        .default as ReturnType<typeof vi.fn>;
+      const [, buildOpts] = buildMock.mock.lastCall as [
+        unknown,
+        { parse: string },
+      ];
+      expect(buildOpts).toEqual({ parse: 'lines' });
+    });
+  });
+});

--- a/packages/data-sanitization-log-providers/test/shared.test.ts
+++ b/packages/data-sanitization-log-providers/test/shared.test.ts
@@ -1,0 +1,156 @@
+/* npm imports */
+import { describe, expect, it } from 'vitest';
+
+/* local imports */
+import { buildErrorPlaceholder, sanitizeLine } from '../src/shared';
+
+describe('shared', () => {
+  describe('sanitizeLine', () => {
+    it('should return unchanged sanitized and null warning when no sensitive fields', () => {
+      // Arrange
+      const line = '{"level":30,"time":1,"msg":"hello"}';
+
+      // Act
+      const result = sanitizeLine(line, {}, ['time']);
+
+      // Assert
+      expect(result.sanitized).toBe(line);
+      expect(result.warning).toBeNull();
+    });
+
+    it('should return sanitized string and null warning when fields match but no change', () => {
+      // Arrange
+      const line = '{"level":30,"msg":"no secrets here"}';
+
+      // Act
+      const result = sanitizeLine(line, { customPatterns: ['email'] }, []);
+
+      // Assert
+      expect(result.sanitized).toBe(line);
+      expect(result.warning).toBeNull();
+    });
+
+    it('should return sanitized string with masked field', () => {
+      // Arrange
+      const line = '{"level":30,"password":"secret","msg":"login"}';
+
+      // Act
+      const result = sanitizeLine(line, {}, []);
+
+      // Assert
+      expect(result.sanitized).not.toContain('"secret"');
+      expect(result.sanitized).toContain('**********');
+    });
+
+    it('should return non-null warning when a field changed', () => {
+      // Arrange
+      const line = '{"level":30,"time":1,"password":"secret","msg":"login"}';
+
+      // Act
+      const result = sanitizeLine(line, {}, ['time']);
+
+      // Assert
+      expect(result.warning).not.toBeNull();
+      const parsed = JSON.parse(result.warning as string) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed.fields).toEqual(['password']);
+    });
+
+    it('should include allowedFields in the warning', () => {
+      // Arrange
+      const line =
+        '{"level":30,"time":1716667200000,"pid":99,"password":"secret","msg":"hi"}';
+
+      // Act
+      const result = sanitizeLine(line, {}, ['time', 'pid']);
+
+      // Assert
+      const parsed = JSON.parse(result.warning as string) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed.time).toBe(1716667200000);
+      expect(parsed.pid).toBe(99);
+    });
+
+    it('should return a warning with fields array when allowedFields is empty and a field changed', () => {
+      // Arrange
+      const line = '{"level":30,"password":"secret","msg":"login"}';
+
+      // Act
+      const result = sanitizeLine(line, {}, []);
+
+      // Assert
+      expect(result.warning).not.toBeNull();
+      const parsed = JSON.parse(result.warning as string) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed.fields).toEqual(['password']);
+      expect(parsed.level).toBe(40);
+    });
+  });
+
+  describe('buildErrorPlaceholder', () => {
+    it('should return error-level JSON with msg when original is valid JSON', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":1716667200000,"pid":99,"hostname":"api-1","msg":"hi"}';
+
+      // Act
+      const result = buildErrorPlaceholder(original);
+      const parsed = JSON.parse(result) as Record<string, unknown>;
+
+      // Assert
+      expect(parsed.level).toBe(50);
+      expect(parsed.msg).toBe('log entry dropped: sanitization failed');
+    });
+
+    it('should preserve time, pid, and hostname from original', () => {
+      // Arrange
+      const original =
+        '{"level":30,"time":123,"pid":42,"hostname":"host","msg":"hi"}';
+
+      // Act
+      const parsed = JSON.parse(buildErrorPlaceholder(original)) as Record<
+        string,
+        unknown
+      >;
+
+      // Assert
+      expect(parsed.time).toBe(123);
+      expect(parsed.pid).toBe(42);
+      expect(parsed.hostname).toBe('host');
+    });
+
+    it('should omit missing optional fields', () => {
+      // Arrange
+      const original = '{"level":30,"msg":"hi"}';
+
+      // Act
+      const parsed = JSON.parse(buildErrorPlaceholder(original)) as Record<
+        string,
+        unknown
+      >;
+
+      // Assert
+      expect(parsed).not.toHaveProperty('time');
+      expect(parsed).not.toHaveProperty('pid');
+      expect(parsed).not.toHaveProperty('hostname');
+    });
+
+    it('should not include sensitive fields from original', () => {
+      // Arrange
+      const original = '{"level":30,"password":"secret","msg":"hi"}';
+
+      // Act
+      const result = buildErrorPlaceholder(original);
+
+      // Assert
+      expect(result).not.toContain('secret');
+      expect(result).not.toContain('password');
+    });
+  });
+});

--- a/packages/data-sanitization-log-providers/test/winston.test.ts
+++ b/packages/data-sanitization-log-providers/test/winston.test.ts
@@ -1,0 +1,252 @@
+/* npm imports */
+import { Writable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+/* local imports */
+import { SanitizingTransport, createSanitizingTransport } from '../src/winston';
+
+const MESSAGE = Symbol.for('message');
+
+function makeStream(): { stream: Writable; lines: () => string[] } {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk: Buffer | string, _enc: string, cb: () => void) {
+      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      cb();
+    },
+  });
+  return { lines: () => chunks, stream };
+}
+
+function makeInfo(msg: string, raw: string): Record<string | symbol, unknown> {
+  return { level: 'info', message: msg, [MESSAGE]: raw };
+}
+
+describe('winston', () => {
+  describe('createSanitizingTransport', () => {
+    it('should return a SanitizingTransport instance', () => {
+      expect(createSanitizingTransport()).toBeInstanceOf(SanitizingTransport);
+    });
+  });
+
+  describe('SanitizingTransport', () => {
+    it('should write the original line unchanged when no sensitive fields are present', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({ stream });
+      const raw = '{"level":"info","msg":"hello"}';
+      const info = makeInfo('hello', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()).toEqual([raw + '\n']);
+    });
+
+    it('should sanitize a sensitive field', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({ stream });
+      const raw = '{"level":"info","password":"secret","msg":"login"}';
+      const info = makeInfo('login', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()[0]).not.toContain('"secret"');
+      expect(lines()[0]).toContain('**********');
+    });
+
+    it('should not emit a warning line when emitWarning is false (default)', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({ stream });
+      const raw = '{"level":"info","password":"secret","msg":"login"}';
+      const info = makeInfo('login', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()).toHaveLength(1);
+    });
+
+    it('should emit a warning line before the sanitized line when emitWarning is true', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({
+        allowedFields: ['timestamp'],
+        emitWarning: true,
+        stream,
+      });
+      const raw =
+        '{"level":"info","timestamp":"2024-01-01","password":"secret","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()).toHaveLength(2);
+      const warning = JSON.parse(lines()[0]) as Record<string, unknown>;
+      expect(warning.level).toBe(40);
+      expect(warning.msg).toBe('sensitive data found in log entry');
+      expect(warning.fields).toEqual(['password']);
+      expect(warning.timestamp).toBe('2024-01-01');
+    });
+
+    it('should not emit a warning line when emitWarning is true but no fields changed', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({ emitWarning: true, stream });
+      const raw = '{"level":"info","msg":"clean"}';
+      const info = makeInfo('clean', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()).toHaveLength(1);
+    });
+
+    it('should use default empty allowedFields so no extra fields appear in warning', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({ emitWarning: true, stream });
+      const raw =
+        '{"level":"info","service":"api","timestamp":"t","password":"secret","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      const warning = JSON.parse(lines()[0]) as Record<string, unknown>;
+      expect(warning).not.toHaveProperty('service');
+      expect(warning).not.toHaveProperty('timestamp');
+    });
+
+    it('should write JSON.stringify of info when MESSAGE is not a string', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({ stream });
+      const info = { level: 'info', message: 'hi' }; // no MESSAGE symbol
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()[0]).toContain('"message":"hi"');
+    });
+
+    it('should call onError and write placeholder when sanitization throws', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const onError = vi.fn();
+      const transport = new SanitizingTransport({
+        onError,
+        sanitize: {
+          customMatchers: [
+            () => {
+              throw new Error('boom');
+            },
+          ],
+        },
+        stream,
+      });
+      const raw = '{"level":"info","password":"secret","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(onError).toHaveBeenCalledOnce();
+      const parsed = JSON.parse(lines()[0]) as Record<string, unknown>;
+      expect(parsed.level).toBe(50);
+    });
+
+    it('should emit logged event and call callback', () => {
+      // Arrange
+      const { stream } = makeStream();
+      const transport = new SanitizingTransport({ stream });
+      const callback = vi.fn();
+      const loggedListener = vi.fn();
+      transport.on('logged', loggedListener);
+      const raw = '{"level":"info","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, callback);
+
+      // Assert
+      expect(callback).toHaveBeenCalledOnce();
+      expect(loggedListener).toHaveBeenCalledOnce();
+    });
+
+    it('should accept custom sanitize options', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({
+        sanitize: { customPatterns: ['email'] },
+        stream,
+      });
+      const raw = '{"level":"info","email":"mark@example.com","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(lines()[0]).not.toContain('mark@example.com');
+    });
+
+    it('should silently continue when sanitization throws and no onError is provided', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const transport = new SanitizingTransport({
+        sanitize: {
+          customMatchers: [
+            () => {
+              throw new Error('boom');
+            },
+          ],
+        },
+        stream,
+      });
+      const raw = '{"level":"info","password":"secret","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      const parsed = JSON.parse(lines()[0]) as Record<string, unknown>;
+      expect(parsed.level).toBe(50);
+    });
+
+    it('should write to process.stdout by default', () => {
+      // Arrange
+      const transport = new SanitizingTransport();
+      const written: string[] = [];
+      const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation((chunk) => {
+          written.push(typeof chunk === 'string' ? chunk : String(chunk));
+          return true;
+        });
+      const raw = '{"level":"info","msg":"hi"}';
+      const info = makeInfo('hi', raw);
+
+      // Act
+      transport.log(info, () => undefined);
+      spy.mockRestore();
+
+      // Assert
+      expect(written).toHaveLength(1);
+      expect(written[0]).toContain('"msg":"hi"');
+    });
+  });
+});

--- a/packages/data-sanitization-log-providers/test/winston.test.ts
+++ b/packages/data-sanitization-log-providers/test/winston.test.ts
@@ -203,6 +203,27 @@ describe('winston', () => {
       expect(lines()[0]).not.toContain('mark@example.com');
     });
 
+    it('should call onError and write placeholder when JSON.stringify throws for non-string MESSAGE', () => {
+      // Arrange
+      const { stream, lines } = makeStream();
+      const onError = vi.fn();
+      const transport = new SanitizingTransport({ onError, stream });
+      const info: Record<string | symbol, unknown> = {
+        level: 'info',
+        message: 'hi',
+      };
+      info.circular = info;
+
+      // Act
+      transport.log(info, () => undefined);
+
+      // Assert
+      expect(onError).toHaveBeenCalledOnce();
+      const parsed = JSON.parse(lines()[0]) as Record<string, unknown>;
+      expect(parsed.level).toBe(50);
+      expect(parsed.msg).toBe('log entry dropped: sanitization failed');
+    });
+
     it('should silently continue when sanitization throws and no onError is provided', () => {
       // Arrange
       const { stream, lines } = makeStream();

--- a/packages/data-sanitization-log-providers/tsconfig.build.json
+++ b/packages/data-sanitization-log-providers/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*"],
+  "exclude": ["./test/**/*", "./dist/**/*"],
+  "compilerOptions": {
+    "incremental": false,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  }
+}

--- a/packages/data-sanitization-log-providers/tsconfig.json
+++ b/packages/data-sanitization-log-providers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src/**/*", "./test/**/*"],
+  "compilerOptions": {
+    "incremental": true,
+    "noEmit": true,
+    "outDir": "./dist",
+    "types": ["node"]
+  }
+}

--- a/packages/data-sanitization-log-providers/vitest.config.ts
+++ b/packages/data-sanitization-log-providers/vitest.config.ts
@@ -1,0 +1,10 @@
+import { mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.config.base';
+
+export default mergeConfig(baseConfig, {
+  test: {
+    coverage: {
+      exclude: ['src/types.ts'],
+    },
+  },
+});

--- a/packages/data-sanitization/src/index.ts
+++ b/packages/data-sanitization/src/index.ts
@@ -2,6 +2,8 @@ import { DataSanitizationError } from './errors';
 import { objectReplacer, stringReplacer } from './replacers';
 import { DataSanitizationReplacer } from './types';
 
+export type { DataSanitizationReplacerOptions } from './types';
+
 /**
  * Returns a safe type label for data passed to the sanitizer.
  *

--- a/packages/data-sanitization/src/types.ts
+++ b/packages/data-sanitization/src/types.ts
@@ -90,7 +90,7 @@ interface BuildSanitizedWarningOptions {
    * object into the warning entry. When omitted, all fields whose values
    * did not change are included.
    */
-  allowedFields?: string[];
+  allowedFields?: readonly string[];
 }
 
 /**

--- a/packages/data-sanitization/vitest.config.ts
+++ b/packages/data-sanitization/vitest.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vitest/config';
+import { mergeConfig } from 'vitest/config';
 import { resolve } from 'node:path';
+import baseConfig from '../../vitest.config.base';
 
-export default defineConfig({
+export default mergeConfig(baseConfig, {
   benchmark: {
     include: ['bench/**/*.bench.ts'],
   },
@@ -13,17 +14,7 @@ export default defineConfig({
   test: {
     coverage: {
       exclude: ['src/constants.ts', 'src/types.ts'],
-      include: ['src/**/*.ts'],
-      provider: 'v8',
-      reporter: ['text', 'json-summary', 'json'],
-      thresholds: {
-        branches: 100,
-        functions: 100,
-        lines: 100,
-        statements: 100,
-      },
     },
-    exclude: ['dist/**', 'node_modules/**', 'scripts/**'],
-    include: ['test/**/*.test.ts'],
+    exclude: ['scripts/**'],
   },
 });

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      include: ['src/**/*.ts'],
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'json'],
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+    exclude: ['dist/**', 'node_modules/**'],
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
 "@commitlint/cli@npm:^21.0.1":
   version: 21.0.1
   resolution: "@commitlint/cli@npm:21.0.1"
@@ -267,6 +274,17 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": "npm:0.3.9"
   checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "@dabh/diagnostics@npm:2.0.8"
+  dependencies:
+    "@so-ric/colorspace": "npm:^1.1.6"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: 10c0/64701c272f7de02800039fea99796507670fe5f67d4eb7718599351ec156936efd123fcab7ee18f9d7874939caaacc08e7c7a6bb05ff8cda6d930ad041cc555c
   languageName: node
   linkType: hard
 
@@ -894,6 +912,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pinojs/redact@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@pinojs/redact@npm:0.4.0"
+  checksum: 10c0/4b311ba17ee0cf154ff9c39eb063ec04cd0d0017cb3750efcdf06c2d485df3e1095e13e872175993568c5568c23e4508dd877c981bbc9c5ae5e384d569efcdff
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.2":
   version: 1.0.2
   resolution: "@rolldown/binding-android-arm64@npm:1.0.2"
@@ -1033,6 +1058,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@so-ric/colorspace@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@so-ric/colorspace@npm:1.1.6"
+  dependencies:
+    color: "npm:^5.0.2"
+    text-hex: "npm:1.0.x"
+  checksum: 10c0/f3ad26afefbb8d6101ea7c385cd5f402d4291c2ffc9cabe37030d5fdb8bda980ee534a0d7c250f8233fc3a59b99272410177cd98b219f6b3770f91a0fdb6eb3e
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
@@ -1137,6 +1172,13 @@ __metadata:
   dependencies:
     undici-types: "npm:>=7.24.0 <7.24.7"
   checksum: 10c0/9a04682842bebbcf21a1779dfeab9aa733d7bd7bbc0a0edb641ab3a9a3d43eac543225acf669c334f458f1956443ebc072bc3c72840c543b8b356cab5c82d456
+  languageName: node
+  linkType: hard
+
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
   languageName: node
   linkType: hard
 
@@ -1382,10 +1424,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.0.0":
+"async@npm:^3.0.0, async@npm:^3.2.3":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
   checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
+  languageName: node
+  linkType: hard
+
+"atomic-sleep@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "atomic-sleep@npm:1.0.0"
+  checksum: 10c0/e329a6665512736a9bbb073e1761b4ec102f7926cce35037753146a9db9c8104f5044c1662e4a863576ce544fb8be27cd2be6bc8c1a40147d03f31eb1cfb6e8a
   languageName: node
   linkType: hard
 
@@ -1504,10 +1553,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "color-convert@npm:3.1.3"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10c0/427648b442c6ea6dab5ba03f4962201ee59f128c80b25d5a0f7d9aab0ef52519a9db8a9bb3cf40b73f86eb19b5ca6aeb0ab930665f3d14973ce776d7d0448a15
+  languageName: node
+  linkType: hard
+
+"color-name@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "color-name@npm:2.1.0"
+  checksum: 10c0/9c953caba99557fce472232ded438c56b902c569cb15d66fcfbdf6374206126eef52ab66459f3984d4074b4aa8ab95e6f4b31a8e4f228dea57d0afecf94281fa
+  languageName: node
+  linkType: hard
+
 "color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^2.1.3":
+  version: 2.1.4
+  resolution: "color-string@npm:2.1.4"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10c0/18a9fefec153d885e0dbfb076f3a65cdcd19f52d96c719f2f261e90e5b7dafd13c51baac399d7099eac290f004d340045ab9467312dcc8afefe6f877ec5c4428
+  languageName: node
+  linkType: hard
+
+"color@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "color@npm:5.0.3"
+  dependencies:
+    color-convert: "npm:^3.1.3"
+    color-string: "npm:^2.1.3"
+  checksum: 10c0/f08a03c5113ae4aa36dba9d2438596b194b897e18b961310643cb63872add1da507cd238df264eb434bbdbe3a377ec41f90d877531acca611523cfcd365db1b6
   languageName: node
   linkType: hard
 
@@ -1609,12 +1693,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-sanitization@workspace:packages/data-sanitization":
+"data-sanitization-log-providers@workspace:packages/data-sanitization-log-providers":
+  version: 0.0.0-use.local
+  resolution: "data-sanitization-log-providers@workspace:packages/data-sanitization-log-providers"
+  dependencies:
+    "@types/node": "npm:^25.9.0"
+    "@vitest/coverage-v8": "npm:^4.1.6"
+    data-sanitization: "workspace:*"
+    oxfmt: "npm:^0.51.0"
+    oxlint: "npm:^1.66.0"
+    pino: "npm:^9.0.0"
+    pino-abstract-transport: "npm:^2.0.0"
+    typescript: "npm:^6.0.3"
+    vitest: "npm:^4.1.6"
+    winston: "npm:^3.19.0"
+    winston-transport: "npm:^4.9.0"
+  peerDependencies:
+    data-sanitization: ">=1.5.0"
+    pino: ">=9.0.0"
+    pino-abstract-transport: ">=2.0.0"
+    winston: ">=3.0.0"
+  peerDependenciesMeta:
+    pino:
+      optional: true
+    pino-abstract-transport:
+      optional: true
+    winston:
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"data-sanitization@workspace:*, data-sanitization@workspace:packages/data-sanitization":
   version: 0.0.0-use.local
   resolution: "data-sanitization@workspace:packages/data-sanitization"
   dependencies:
     "@types/node": "npm:^25.9.0"
     "@vitest/coverage-v8": "npm:^4.1.6"
+    oxfmt: "npm:^0.51.0"
+    oxlint: "npm:^1.66.0"
     query-string: "npm:^9.3.1"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.6"
@@ -1709,6 +1825,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 10c0/b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 10c0/3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
   languageName: node
   linkType: hard
 
@@ -1871,6 +1994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
+  languageName: node
+  linkType: hard
+
 "fill-range@npm:^7.1.1":
   version: 7.1.1
   resolution: "fill-range@npm:7.1.1"
@@ -1884,6 +2014,13 @@ __metadata:
   version: 5.1.0
   resolution: "filter-obj@npm:5.1.0"
   checksum: 10c0/716e8ad2bc352e206556b3e5695b3cdff8aab80c53ea4b00c96315bbf467b987df3640575100aef8b84e812cf5ea4251db4cd672bbe33b1e78afea88400c67dd
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 10c0/8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
   languageName: node
   linkType: hard
 
@@ -2053,6 +2190,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inherits@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
 "ini@npm:6.0.0":
   version: 6.0.0
   resolution: "ini@npm:6.0.0"
@@ -2165,6 +2309,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-stream@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^4.0.0":
   version: 4.0.0
   resolution: "isexe@npm:4.0.0"
@@ -2270,6 +2421,13 @@ __metadata:
   bin:
     katex: cli.js
   checksum: 10c0/b10f4d0651c60771a48444879e4227255e26e2b2ec061b1ee4b08934863ad2324ba8dbb772455f7768aeb14dfcc13bcd309174a0ddd5ef954a607f644a197710
+  languageName: node
+  linkType: hard
+
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 10c0/0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
   languageName: node
   linkType: hard
 
@@ -2450,6 +2608,20 @@ __metadata:
     strip-ansi: "npm:^7.1.0"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10c0/4b350c0a83d7753fea34dcac6cd797d1dc9603291565de009baa4aa91c0447eab0d3815a05c8ec9ac04fdfffb43c82adcdb03ec1fceafd8518e1a8c1cff4ff89
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "logform@npm:2.7.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/4789b4b37413c731d1835734cb799240d31b865afde6b7b3e06051d6a4127bfda9e88c99cfbf296d084a315ccbed2647796e6a56b66e725bcb268c586f57558f
   languageName: node
   linkType: hard
 
@@ -2899,7 +3071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.3":
+"ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -2969,6 +3141,22 @@ __metadata:
   version: 2.1.1
   resolution: "obug@npm:2.1.1"
   checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
+  languageName: node
+  linkType: hard
+
+"on-exit-leak-free@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "on-exit-leak-free@npm:2.1.2"
+  checksum: 10c0/faea2e1c9d696ecee919026c32be8d6a633a7ac1240b3b87e944a380e8a11dc9c95c4a1f8fb0568de7ab8db3823e790f12bda45296b1d111e341aad3922a0570
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 10c0/6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
   languageName: node
   linkType: hard
 
@@ -3199,6 +3387,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pino-abstract-transport@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pino-abstract-transport@npm:2.0.0"
+  dependencies:
+    split2: "npm:^4.0.0"
+  checksum: 10c0/02c05b8f2ffce0d7c774c8e588f61e8b77de8ccb5f8125afd4a7325c9ea0e6af7fb78168999657712ae843e4462bb70ac550dfd6284f930ee57f17f486f25a9f
+  languageName: node
+  linkType: hard
+
+"pino-std-serializers@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "pino-std-serializers@npm:7.1.0"
+  checksum: 10c0/d158615aa93ebdeac2d3912ad4227a23ef78cf14229e886214771f581e96eff312257f2d6368c75b2fbf53e5024eda475d81305014f4ed1a6d5eeab9107f6ef0
+  languageName: node
+  linkType: hard
+
+"pino@npm:^9.0.0":
+  version: 9.14.0
+  resolution: "pino@npm:9.14.0"
+  dependencies:
+    "@pinojs/redact": "npm:^0.4.0"
+    atomic-sleep: "npm:^1.0.0"
+    on-exit-leak-free: "npm:^2.1.0"
+    pino-abstract-transport: "npm:^2.0.0"
+    pino-std-serializers: "npm:^7.0.0"
+    process-warning: "npm:^5.0.0"
+    quick-format-unescaped: "npm:^4.0.3"
+    real-require: "npm:^0.2.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    sonic-boom: "npm:^4.0.1"
+    thread-stream: "npm:^3.0.0"
+  bin:
+    pino: bin.js
+  checksum: 10c0/9a10d9bf820a585eae9bc270fb4e55c895e48280d54adbbb4063ec061694b22d8809c80203cf5fe9f920a54c832b0b8dfb67cb28a04baa13abebaf261a9c9f3e
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
@@ -3214,6 +3439,13 @@ __metadata:
   version: 6.1.0
   resolution: "proc-log@npm:6.1.0"
   checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+  languageName: node
+  linkType: hard
+
+"process-warning@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "process-warning@npm:5.0.0"
+  checksum: 10c0/941f48863d368ec161e0b5890ba0c6af94170078f3d6b5e915c19b36fb59edb0dc2f8e834d25e0d375a8bf368a49d490f080508842168832b93489d17843ec29
   languageName: node
   linkType: hard
 
@@ -3239,6 +3471,31 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: 10c0/900a93d3cdae3acd7d16f642c29a642aea32c2026446151f0778c62ac089d4b8e6c986811076e1ae180a694cedf077d453a11b58ff0a865629a4f82ab558e102
+  languageName: node
+  linkType: hard
+
+"quick-format-unescaped@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "quick-format-unescaped@npm:4.0.4"
+  checksum: 10c0/fe5acc6f775b172ca5b4373df26f7e4fd347975578199e7d74b2ae4077f0af05baa27d231de1e80e8f72d88275ccc6028568a7a8c9ee5e7368ace0e18eff93a4
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"real-require@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "real-require@npm:0.2.0"
+  checksum: 10c0/23eea5623642f0477412ef8b91acd3969015a1501ed34992ada0e3af521d3c865bb2fe4cdbfec5fe4b505f6d1ef6a03e5c3652520837a8c3b53decff7e74b6a0
   languageName: node
   linkType: hard
 
@@ -3386,6 +3643,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:~5.2.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -3464,6 +3735,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sonic-boom@npm:^4.0.1":
+  version: 4.2.1
+  resolution: "sonic-boom@npm:4.2.1"
+  dependencies:
+    atomic-sleep: "npm:^1.0.0"
+  checksum: 10c0/f374e9c3dfe194d706d8ef8aed4e28bc10638f9952fd19bcbddf2cef05d53334ad9e9dca3e01e24e88dd88fb278c6b8c5b2ae5002494b289c4914aaea3d9eae9
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -3475,6 +3755,20 @@ __metadata:
   version: 3.0.0
   resolution: "split-on-first@npm:3.0.0"
   checksum: 10c0/a1262eae12b68de235e1a08e011bf5b42c42621985ddf807e6221fb1e2b3304824913ae7019f18436b96b8fab8aef5f1ad80dedd2385317fdc51b521c3882cd0
+  languageName: node
+  linkType: hard
+
+"split2@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "split2@npm:4.2.0"
+  checksum: 10c0/b292beb8ce9215f8c642bb68be6249c5a4c7f332fc8ecadae7be5cbdf1ea95addc95f0459ef2e7ad9d45fd1064698a097e4eb211c83e772b49bc0ee423e91534
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
   languageName: node
   linkType: hard
 
@@ -3541,6 +3835,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string_decoder@npm:^1.1.1":
+  version: 1.3.0
+  resolution: "string_decoder@npm:1.3.0"
+  dependencies:
+    safe-buffer: "npm:~5.2.0"
+  checksum: 10c0/810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
+  languageName: node
+  linkType: hard
+
 "strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -3578,6 +3881,22 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/8f039edb1d12fdd7df6c6f9877d125afe9f3da3f5f9317df326fdd090d48793d6998cede1506a1471f3e3a250db270a89dace28005eb5e99c5a9132d704ac956
+  languageName: node
+  linkType: hard
+
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
+"thread-stream@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "thread-stream@npm:3.1.0"
+  dependencies:
+    real-require: "npm:^0.2.0"
+  checksum: 10c0/c36118379940b77a6ef3e6f4d5dd31e97b8210c3f7b9a54eb8fe6358ab173f6d0acfaf69b9c3db024b948c0c5fd2a7df93e2e49151af02076b35ada3205ec9a6
   languageName: node
   linkType: hard
 
@@ -3625,6 +3944,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 10c0/4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
   languageName: node
   linkType: hard
 
@@ -3718,6 +4044,13 @@ __metadata:
   version: 0.4.0
   resolution: "unicorn-magic@npm:0.4.0"
   checksum: 10c0/cd6eff90967a5528dfa2016bdb5b38b0cd64c8558f9ba04fb5c2c23f3a232a67dfe2bfa4c45af3685d5f1a40dbac6a36d48e053f80f97ae4da1e0f6a55431685
+  languageName: node
+  linkType: hard
+
+"util-deprecate@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "util-deprecate@npm:1.0.2"
+  checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
   languageName: node
   linkType: hard
 
@@ -3873,6 +4206,36 @@ __metadata:
   bin:
     why-is-node-running: cli.js
   checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "winston-transport@npm:4.9.0"
+  dependencies:
+    logform: "npm:^2.7.0"
+    readable-stream: "npm:^3.6.2"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/e2990a172e754dbf27e7823772214a22dc8312f7ec9cfba831e5ef30a5d5528792e5ea8f083c7387ccfc5b2af20e3691f64738546c8869086110a26f98671095
+  languageName: node
+  linkType: hard
+
+"winston@npm:^3.19.0":
+  version: 3.19.0
+  resolution: "winston@npm:3.19.0"
+  dependencies:
+    "@colors/colors": "npm:^1.6.0"
+    "@dabh/diagnostics": "npm:^2.0.8"
+    async: "npm:^3.2.3"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.7.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.9.0"
+  checksum: 10c0/341a8ccfb726120209d34e2466040e2ca72cadb1a3402c4fc90425facad002b81275675b4ab9b4432a624311bc47ef7c9fb7652c86fca454d2be2f2ee1882226
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Overview

Add a new `data-sanitization-log-providers` companion package with pre-built adapters for pino and winston. Also introduces a shared vitest base config, per-package tooling scripts, and fixes CI coverage reporting for the new package.

## Details

- New `data-sanitization-log-providers` package with three subpath exports:
  - `/pino-hook` — synchronous `streamWrite` hook for main-thread sanitization with configurable error handling and optional warning emission
  - `/pino-transport` — worker-thread `pino-abstract-transport` adapter
  - `/winston` — `TransportStream` subclass that sanitizes log entries before writing
- Export `DataSanitizationReplacerOptions` from `data-sanitization` (required by log-providers)
- Add shared `vitest.config.base.ts` at repo root; both packages extend it via `mergeConfig`
- Add per-package `lint`, `lint:fix`, `format`, `format:check` scripts with `oxlint`/`oxfmt` in each package's `devDependencies` for Yarn PnP resolution
- Add `volta` pins to each package's `package.json` so correct Node/Yarn versions are used from package subdirectories
- Fix CI coverage Gist update step for the new package (was running from wrong working directory)
- Update `npmMinimalAgeGate` from `0` to `10`

## Related Tickets and/or Pull Requests

Closes #309

## Checklist

- [x] Tests added or updated
- [x] README and TSDoc updated if the public API changed
- [ ] Breaking changes called out (if any)
- [x] Roadmap item checked off if this PR completes one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a log-sanitization package with Pino (hook + worker transport) and Winston adapters to redact sensitive fields and emit optional structured warnings.

* **Documentation**
  * Added a full README and a design plan describing usage, options, warning behavior, and error handling.

* **Tests**
  * Added comprehensive tests for sanitization, warnings, error handling, backpressure, and adapter wiring.

* **Chores**
  * Improved CI coverage reporting and updated test/tooling/configuration and Yarn settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->