### PR TITLE
feat(data-sanitization): export additional public types and optimize string replacer

### DIFF
--- a/packages/data-sanitization-log-providers/src/pino-transport.ts
+++ b/packages/data-sanitization-log-providers/src/pino-transport.ts
@@ -1,17 +1,17 @@
 import { once } from 'node:events';
 import build from 'pino-abstract-transport';
-
-const writeLine = async (line: string): Promise<void> => {
-  if (!process.stdout.write(line + '\n')) {
-    await once(process.stdout, 'drain');
-  }
-};
 import {
   buildErrorPlaceholder,
   PINO_DEFAULT_ALLOWED_FIELDS,
   sanitizeLine,
 } from './shared.js';
 import type { PinoTransportOptions } from './types.js';
+
+const writeLine = async (line: string): Promise<void> => {
+  if (!process.stdout.write(line + '\n')) {
+    await once(process.stdout, 'drain');
+  }
+};
 
 /**
  * Pino `pino-abstract-transport` worker module.

--- a/packages/data-sanitization-log-providers/test/pino-hook.test.ts
+++ b/packages/data-sanitization-log-providers/test/pino-hook.test.ts
@@ -83,7 +83,7 @@ describe('pino-hook', () => {
       expect(warning).not.toHaveProperty('hostname');
     });
 
-    it('should emit no warning when allowedFields is empty and field changed', () => {
+    it('should emit a warning with only fields metadata when allowedFields is empty', () => {
       // Arrange
       const hook = createSanitizeLogLine({ allowedFields: [] });
 
@@ -91,7 +91,7 @@ describe('pino-hook', () => {
       const result = hook(dirty);
       const lines = result.split('\n').filter(Boolean);
 
-      // Assert — warning is still emitted (fields array always present), just has no extra fields
+      // Assert
       expect(lines).toHaveLength(2);
       const warning = JSON.parse(lines[0]) as Record<string, unknown>;
       expect(warning.fields).toEqual(['password']);

--- a/packages/data-sanitization-log-providers/vitest.config.ts
+++ b/packages/data-sanitization-log-providers/vitest.config.ts
@@ -1,7 +1,26 @@
 import { mergeConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 import baseConfig from '../../vitest.config.base';
 
 export default mergeConfig(baseConfig, {
+  resolve: {
+    alias: [
+      {
+        find: 'data-sanitization/utils',
+        replacement: resolve(
+          import.meta.dirname,
+          '../data-sanitization/src/utils.ts',
+        ),
+      },
+      {
+        find: 'data-sanitization',
+        replacement: resolve(
+          import.meta.dirname,
+          '../data-sanitization/src/index.ts',
+        ),
+      },
+    ],
+  },
   test: {
     coverage: {
       exclude: ['src/types.ts'],

--- a/packages/data-sanitization/README.md
+++ b/packages/data-sanitization/README.md
@@ -425,7 +425,9 @@ regex must use capture groups `$1` and `$2` to preserve the field name and
 trailing delimiter while replacing the value.
 
 ```typescript
-const headerMatcher = (pattern: string) =>
+import type { DataSanitizationMatcher } from 'data-sanitization';
+
+const headerMatcher: DataSanitizationMatcher = (pattern) =>
   new RegExp(`(${pattern}:\\s*).+?(\\n|$)`, 'gi');
 
 sanitizeData('authorization: Bearer abc123\nuser: mark', {

--- a/packages/data-sanitization/src/index.ts
+++ b/packages/data-sanitization/src/index.ts
@@ -2,7 +2,13 @@ import { DataSanitizationError } from './errors';
 import { objectReplacer, stringReplacer } from './replacers';
 import { DataSanitizationReplacer } from './types';
 
-export type { DataSanitizationReplacerOptions } from './types';
+export type {
+  DataSanitizationInput,
+  DataSanitizationMatcher,
+  DataSanitizationOutput,
+  DataSanitizationReplacer,
+  DataSanitizationReplacerOptions,
+} from './types';
 
 /**
  * Returns a safe type label for data passed to the sanitizer.

--- a/packages/data-sanitization/src/replacers.ts
+++ b/packages/data-sanitization/src/replacers.ts
@@ -168,10 +168,9 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const matchers = buildMatchers(useDefaultMatchers, customMatchers);
 
   const replacement = removeMatches ? '' : '$1' + mask + '$2';
-  for (const pattern of patterns) {
-    for (const matcher of matchers) {
-      data = data.replace(matcher(pattern, removeMatches), replacement);
-    }
+  const { regexes } = buildStringScanRegexes(matchers, patterns, removeMatches);
+  for (const regex of regexes) {
+    data = data.replace(regex, replacement);
   }
 
   return data;

--- a/packages/data-sanitization/test/replacers.test.ts
+++ b/packages/data-sanitization/test/replacers.test.ts
@@ -282,6 +282,36 @@ describe('DataSanitizationReplacers', () => {
         expect(replacedData).toContain('username=mark');
       });
 
+      it('should reuse compiled custom matcher regexes for repeated string sanitization', () => {
+        // Arrange
+        let matcherCalls = 0;
+        const matcher = (pattern: string): RegExp => {
+          matcherCalls++;
+          return new RegExp(`(${pattern}=)[^&\n]+(&|$)`, 'gi');
+        };
+        const options = {
+          customMatchers: [matcher],
+          customPatterns: ['cache_key'],
+          useDefaultMatchers: false,
+          useDefaultPatterns: false,
+        };
+
+        // Act
+        const first = stringReplacer(
+          'cache_key=first&username=mark',
+          options,
+        ) as string;
+        const second = stringReplacer(
+          'cache_key=second&username=mark',
+          options,
+        ) as string;
+
+        // Assert
+        expect(first).toBe(`cache_key=${DEFAULT_PATTERN_MASK}&username=mark`);
+        expect(second).toBe(`cache_key=${DEFAULT_PATTERN_MASK}&username=mark`);
+        expect(matcherCalls).toBe(1);
+      });
+
       it('should skip default patterns when useDefaultPatterns is false', () => {
         // Arrange
         const testData = '{"password":"foo","username":"bar"}';


### PR DESCRIPTION
# Overview

Exports four additional public types from `data-sanitization` so consumers can properly type-annotate custom matchers and replacers. Also pre-compiles string scan regexes in `stringReplacer` to avoid redundant matcher calls on repeated invocations.

## Details

- Export `DataSanitizationInput`, `DataSanitizationMatcher`, `DataSanitizationOutput`, and `DataSanitizationReplacer` from the public API
- Pre-compile string scan regexes via `buildStringScanRegexes` to skip redundant matcher calls across repeated `stringReplacer` calls
- Fix README custom matcher example to use `DataSanitizationMatcher` with a proper import
- Add `data-sanitization` path aliases in the log-providers vitest config for accurate source imports during tests

## Related Tickets and/or Pull Requests

N/A

## Checklist

- [x] Tests added or updated
- [x] README and TSDoc updated if the public API changed
- [ ] Breaking changes called out (if any)
- [ ] Roadmap item checked off if this PR completes one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public type exports from the data-sanitization package for improved TypeScript support and developer experience.

* **Documentation**
  * Updated README example to demonstrate explicit type usage when defining custom data sanitization matchers.

* **Bug Fixes**
  * Adjusted warning behavior when `allowedFields` is configured as an empty array to include appropriate metadata.

* **Chores**
  * Configuration updates and internal code organization improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->