### PR TITLE
docs: add best-effort framing to README

### DIFF
--- a/packages/data-sanitization/README.md
+++ b/packages/data-sanitization/README.md
@@ -71,6 +71,14 @@ If you control your data shape exactly and need maximum throughput, reach for
 [fast-redact](https://github.com/davidmarkclements/fast-redact). If you need to sanitize data you don't fully control,
 `data-sanitization` is the right tool.
 
+> [!NOTE]
+> **Best-effort by design.** `data-sanitization` is a defensive layer that reduces accidental
+> leakage — it is not a compliance guarantee. Pattern-based sanitization will miss sensitive values
+> when key names don't match the configured patterns, values appear in unsupported formats (such as
+> numeric fields in unparsed JSON strings), or content is embedded in ways no configured matcher
+> recognizes. Use it to catch what might otherwise slip through, not as a substitute for access
+> controls or data-handling policies.
+
 ## Log provider integrations
 
 [`data-sanitization-log-providers`](https://www.npmjs.com/package/data-sanitization-log-providers)


### PR DESCRIPTION
# Overview

Add a callout to the README making explicit that `data-sanitization` is a best-effort defensive layer, not a compliance guarantee.

## Details

Adds a `> [!NOTE]` callout at the close of the "Why not fast-redact" section explaining that pattern-based sanitization will miss sensitive values when key names don't match configured patterns, values appear in unsupported formats, or content is embedded in ways no matcher recognizes. Directs users to treat this as a tool to catch accidental leakage, not as a substitute for access controls or data-handling policies.

The placement is deliberate — the "Why not fast-redact" section is already about tradeoffs and tool selection, making it the natural home for this framing without interrupting the quick-start flow at the top of the README.

## Related Tickets and/or Pull Requests

<!-- No related issue. -->

## Checklist

- [ ] Tests added or updated
- [ ] README and TSDoc updated if the public API changed
- [ ] Breaking changes called out (if any)
- [ ] Roadmap item checked off if this PR completes one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced documentation for data-sanitization, clarifying its best-effort design and limitations. It reduces accidental data leakage but is not a compliance guarantee and may miss sensitive values due to pattern mismatches, unsupported formats, or unrecognized embedded content. Users are advised to implement access controls and data-handling policies as primary security measures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->