### PR TITLE
feat: add ignorePatterns option to suppress false positives

### DIFF
--- a/docs/plans/017-ignore-patterns-option.md
+++ b/docs/plans/017-ignore-patterns-option.md
@@ -1,0 +1,89 @@
+# `ignorePatterns` Option
+
+## Approach
+
+Add an `ignorePatterns` option that lets callers exclude specific key names from
+sanitization. Substring matching is intentional and useful — `resetPasswordToken`
+and `db_password` are correctly caught — but it can also produce false positives:
+a field legitimately named `tokenizer_config` or `has_secrets_manager_access`
+gets masked when it should not. `ignorePatterns` addresses this without changing
+any default behavior.
+
+The option works at the pattern-resolution level: after the full set of active
+patterns is assembled (defaults plus any `customPatterns`), any pattern that
+appears in `ignorePatterns` is removed from the set before regexes are built.
+This applies consistently to both the object and string sanitization paths.
+
+## Steps
+
+1. `docs/plans/017-ignore-patterns-option.md` — add this plan.
+
+2. `packages/data-sanitization/src/types.ts` — add `ignorePatterns?: string[]`
+   to `DataSanitizationReplacerOptions`. Add TSDoc: description, `@param` note
+   that matching uses the same case-insensitive substring logic as
+   `customPatterns`, and an `@example`.
+
+3. `packages/data-sanitization/src/replacers.ts` — in the shared option
+   resolution step (where defaults and custom patterns are merged), filter out
+   any resolved pattern whose value appears in `ignorePatterns` before the regex
+   set is built. This single change applies to both `objectReplacer` and
+   `stringReplacer` via the shared resolver.
+
+4. `packages/data-sanitization/test/replacers.test.ts` — add tests covering:
+   - A key that matches a default pattern is not masked when its pattern is in
+     `ignorePatterns` (`tokenizer_config` with `ignorePatterns: ['token']`).
+   - A key that matches a `customPattern` is not masked when its pattern is in
+     `ignorePatterns`.
+   - Multiple patterns can be ignored simultaneously.
+   - `ignorePatterns: []` (default) has no effect on existing behavior.
+   - Ignoring a pattern does not affect other patterns — other sensitive keys
+     are still masked.
+   - Interaction with `removeMatches: true`.
+   - String input: a pattern in `ignorePatterns` is not applied by the string
+     replacer.
+
+5. `packages/data-sanitization/README.md` — add `ignorePatterns` row to the
+   options table and a short usage example showing `tokenizer_config` passing
+   through unmasked.
+
+## Relevant Files
+
+- `docs/plans/017-ignore-patterns-option.md` — new, this plan.
+- `packages/data-sanitization/src/types.ts` — updated with new option.
+- `packages/data-sanitization/src/replacers.ts` — updated option resolution
+  logic.
+- `packages/data-sanitization/test/replacers.test.ts` — updated with
+  `ignorePatterns` test suite.
+- `packages/data-sanitization/README.md` — updated options table and example.
+
+## Verification
+
+1. Run `yarn workspace data-sanitization test` — all tests pass.
+2. Run `yarn workspace data-sanitization test:coverage` — coverage remains at
+   100%.
+3. Run `yarn workspace data-sanitization build` — no TypeScript errors.
+4. Run `yarn workspace data-sanitization lint:ci`.
+5. Manually confirm the README example is accurate against the implemented
+   behavior.
+
+## Decisions
+
+**Pattern-level filtering, not key-level** — `ignorePatterns` filters the
+resolved pattern set, not individual key names. This means `ignorePatterns:
+['token']` suppresses the entire `token` substring match, not just the literal
+key `token`. This is consistent with how `customPatterns` works and is simpler
+to reason about. If per-key exclusion is needed in the future, it can be a
+separate `ignorePaths` option.
+
+**Applied before regex compilation** — removing ignored patterns before building
+regexes means the cache fingerprint reflects the effective pattern set, not the
+raw options. Two calls with different `ignorePatterns` values that resolve to
+the same active set will correctly share a cache entry.
+
+**Default is `[]`** — no existing behavior changes. The option is purely
+additive.
+
+**Interaction with `useDefaultPatterns: false`** — if `useDefaultPatterns` is
+false, the default patterns are not in the resolved set to begin with, so
+listing them in `ignorePatterns` has no effect. This is the expected and
+least-surprising behavior; no special handling needed.

--- a/packages/data-sanitization/README.md
+++ b/packages/data-sanitization/README.md
@@ -355,6 +355,7 @@ sanitizeData({ tags }, { sanitizeCollections: true });
 | `customMatchers`      | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                                                                                                                |
 | `useDefaultPatterns`  | `boolean`                   | `true`       | Set to `false` to use only your custom patterns, ignoring the built-in defaults.                                                                                                   |
 | `useDefaultMatchers`  | `boolean`                   | `true`       | Set to `false` to use only your custom matchers, ignoring the built-in defaults.                                                                                                   |
+| `ignorePatterns`      | `string[]`                  | `[]`         | Patterns to exclude from the active set. Applied after defaults and `customPatterns` are merged. Use to prevent false positives from built-in substring matching.                  |
 
 ## Default patterns
 
@@ -415,6 +416,32 @@ sanitizeData(data, {
 });
 // => { username: 'mark', ssn: '[REDACTED]', credit_card: '[REDACTED]' }
 ```
+
+Use `ignorePatterns` to prevent a built-in pattern from matching field names
+that are not sensitive in your application. The default `token` pattern, for
+example, would also match `tokenizer_config`:
+
+```typescript
+const data = {
+  tokenizer_config: 'bert-base-uncased',
+  api_key: 'sk-abc123',
+  username: 'mark',
+};
+
+// Without ignorePatterns: tokenizer_config is incorrectly masked
+sanitizeData(data);
+// => { tokenizer_config: '**********', api_key: '**********', username: 'mark' }
+
+// With ignorePatterns: token pattern suppressed, other patterns still active
+sanitizeData(data, { ignorePatterns: ['token'] });
+// => { tokenizer_config: 'bert-base-uncased', api_key: '**********', username: 'mark' }
+```
+
+Note that `ignorePatterns` suppresses the entire substring pattern — any field
+whose name matches the pattern will pass through unmasked. If you have a field
+named `token` alongside `tokenizer_config`, both will be unmasked when `token`
+is ignored. Use `useDefaultPatterns: false` with explicit `customPatterns` for
+fine-grained per-field control.
 
 Number-typed sensitive values are masked with `numericMask` to preserve the
 field's type:

--- a/packages/data-sanitization/src/replacers.ts
+++ b/packages/data-sanitization/src/replacers.ts
@@ -7,19 +7,31 @@ import {
 import defaultMatchers, { escapePattern } from './matchers';
 
 /**
- * Builds the active pattern list from defaults and any caller-supplied patterns.
+ * Builds the active pattern list from defaults and any caller-supplied patterns,
+ * minus any patterns listed in `ignorePatterns`.
  *
  * @param useDefaultPatterns - Whether to include the built-in default patterns.
  * @param customPatterns - Additional patterns to append to the active list.
+ * @param ignorePatterns - Patterns to remove from the assembled list.
  * @returns Combined array of field-name patterns to match against.
  */
 const buildPatterns = (
   useDefaultPatterns: boolean,
   customPatterns?: string[],
-): string[] => [
-  ...(useDefaultPatterns ? DEFAULT_FIELD_NAME_PATTERNS : []),
-  ...(customPatterns ?? []),
-];
+  ignorePatterns?: string[],
+): string[] => {
+  const patterns = [
+    ...(useDefaultPatterns ? DEFAULT_FIELD_NAME_PATTERNS : []),
+    ...(customPatterns ?? []),
+  ];
+
+  if (!ignorePatterns?.length) {
+    return patterns;
+  }
+
+  const ignored = new Set(ignorePatterns.map((p) => p.toLowerCase()));
+  return patterns.filter((p) => !ignored.has(p.toLowerCase()));
+};
 
 /**
  * Builds the active matcher list from defaults and any caller-supplied matchers.
@@ -140,6 +152,7 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const {
     customMatchers,
     customPatterns,
+    ignorePatterns,
     parseJsonStrings = false,
     patternMask,
     removeMatches = false,
@@ -164,7 +177,11 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
   }
 
   const mask = patternMask ?? DEFAULT_PATTERN_MASK;
-  const patterns = buildPatterns(useDefaultPatterns, customPatterns);
+  const patterns = buildPatterns(
+    useDefaultPatterns,
+    customPatterns,
+    ignorePatterns,
+  );
   const matchers = buildMatchers(useDefaultMatchers, customMatchers);
 
   const replacement = removeMatches ? '' : '$1' + mask + '$2';
@@ -202,6 +219,7 @@ const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
   const {
     customMatchers,
     customPatterns,
+    ignorePatterns,
     numericMask,
     patternMask,
     removeMatches = false,
@@ -217,7 +235,11 @@ const objectReplacer: DataSanitizationReplacer = (data, options = {}) => {
 
   const mask = patternMask ?? DEFAULT_PATTERN_MASK;
   const matchers = buildMatchers(useDefaultMatchers, customMatchers);
-  const patterns = buildPatterns(useDefaultPatterns, customPatterns);
+  const patterns = buildPatterns(
+    useDefaultPatterns,
+    customPatterns,
+    ignorePatterns,
+  );
   const keyMatchers = patterns.map(
     (pattern) => new RegExp(`\\w*${escapePattern(pattern)}\\w*`, 'i'),
   );

--- a/packages/data-sanitization/src/types.ts
+++ b/packages/data-sanitization/src/types.ts
@@ -79,6 +79,22 @@ interface DataSanitizationReplacerOptions {
    * Whether to use the built-in default patterns. Default: true
    */
   useDefaultPatterns?: boolean;
+  /**
+   * Patterns to exclude from the active pattern set. Any pattern listed here
+   * is removed after the full set is assembled (defaults plus `customPatterns`)
+   * and before regexes are built. Matching is case-insensitive and uses the
+   * same substring logic as `customPatterns`.
+   *
+   * Use this to prevent false positives where a built-in pattern matches field
+   * names that are not sensitive in your application.
+   *
+   * Default: []
+   *
+   * @example
+   * // Prevent 'token' from matching 'tokenizer_config'
+   * sanitizeData(data, { ignorePatterns: ['token'] })
+   */
+  ignorePatterns?: string[];
 }
 
 /**

--- a/packages/data-sanitization/test/replacers.test.ts
+++ b/packages/data-sanitization/test/replacers.test.ts
@@ -1739,4 +1739,164 @@ describe('DataSanitizationReplacers', () => {
       });
     });
   });
+
+  describe('ignorePatterns option', () => {
+    describe('with object input', () => {
+      it('should not mask a field whose default pattern is ignored', () => {
+        // Arrange
+        const testData = { tokenizer_config: 'bert-base', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: ['token'],
+        }) as typeof testData;
+
+        // Assert
+        expect(result.tokenizer_config).toBe('bert-base');
+        expect(result.username).toBe('mark');
+      });
+
+      it('should still mask other default-pattern fields when one pattern is ignored', () => {
+        // Arrange
+        const testData = {
+          password: 'secret',
+          tokenizer_config: 'bert-base',
+          username: 'mark',
+        };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: ['token'],
+        }) as typeof testData;
+
+        // Assert
+        expect(result.tokenizer_config).toBe('bert-base');
+        expect(result.password).toBe(DEFAULT_PATTERN_MASK);
+        expect(result.username).toBe('mark');
+      });
+
+      it('should not mask a field whose custom pattern is ignored', () => {
+        // Arrange
+        const testData = { internal_ref: 'ABC123', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          customPatterns: ['internal_ref'],
+          ignorePatterns: ['internal_ref'],
+        }) as typeof testData;
+
+        // Assert
+        expect(result.internal_ref).toBe('ABC123');
+        expect(result.username).toBe('mark');
+      });
+
+      it('should suppress multiple patterns when multiple are ignored', () => {
+        // Arrange
+        const testData = {
+          api_key: 'key123',
+          secret: 'shh',
+          username: 'mark',
+        };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: ['api_key', 'secret'],
+        }) as typeof testData;
+
+        // Assert
+        expect(result.api_key).toBe('key123');
+        expect(result.secret).toBe('shh');
+        expect(result.username).toBe('mark');
+      });
+
+      it('should have no effect when ignorePatterns is an empty array', () => {
+        // Arrange
+        const testData = { password: 'secret', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: [],
+        }) as typeof testData;
+
+        // Assert
+        expect(result.password).toBe(DEFAULT_PATTERN_MASK);
+        expect(result.username).toBe('mark');
+      });
+
+      it('should remove a field whose default pattern is not ignored when removeMatches is true', () => {
+        // Arrange
+        const testData = { password: 'secret', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: ['token'],
+          removeMatches: true,
+        }) as Record<string, unknown>;
+
+        // Assert
+        expect(result).not.toHaveProperty('password');
+        expect(result.username).toBe('mark');
+      });
+
+      it('should not remove a field whose pattern is in ignorePatterns when removeMatches is true', () => {
+        // Arrange
+        const testData = { token: 'abc', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: ['token'],
+          removeMatches: true,
+        }) as typeof testData;
+
+        // Assert
+        expect(result.token).toBe('abc');
+        expect(result.username).toBe('mark');
+      });
+
+      it('should match ignorePatterns case-insensitively', () => {
+        // Arrange
+        const testData = { password: 'secret', username: 'mark' };
+
+        // Act
+        const result = objectReplacer(testData, {
+          ignorePatterns: ['PASSWORD'],
+        }) as typeof testData;
+
+        // Assert
+        expect(result.password).toBe('secret');
+        expect(result.username).toBe('mark');
+      });
+    });
+
+    describe('with string input', () => {
+      it('should not mask a field whose default pattern is ignored', () => {
+        // Arrange
+        const testData = 'tokenizer_config=bert-base&username=mark';
+
+        // Act
+        const result = stringReplacer(testData, {
+          ignorePatterns: ['token'],
+        });
+
+        // Assert
+        expect(result).toBe('tokenizer_config=bert-base&username=mark');
+      });
+
+      it('should still mask other default-pattern fields when one pattern is ignored', () => {
+        // Arrange
+        const testData =
+          'tokenizer_config=bert-base&password=secret&username=mark';
+
+        // Act
+        const result = stringReplacer(testData, {
+          ignorePatterns: ['token'],
+        });
+
+        // Assert
+        expect(result).toContain('tokenizer_config=bert-base');
+        expect(result).toContain(`password=${DEFAULT_PATTERN_MASK}`);
+        expect(result).toContain('username=mark');
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Overview

Adds an `ignorePatterns` option to `DataSanitizationReplacerOptions` that lets callers exclude specific patterns from the active set. The built-in `token` pattern matches `tokenizer_config` as a substring — `ignorePatterns: ['token']` prevents that false positive without changing any other defaults.

## Details

- **`src/types.ts`** — new `ignorePatterns?: string[]` field on `DataSanitizationReplacerOptions` with TSDoc and `@example`
- **`src/replacers.ts`** — `buildPatterns` updated to accept and apply `ignorePatterns` after the full pattern set is assembled; both `stringReplacer` and `objectReplacer` thread it through via the shared resolver
- **`test/replacers.test.ts`** — 10 new tests covering: default pattern suppressed, other patterns unaffected, custom pattern ignored, multiple patterns ignored, empty array no-op, `removeMatches` interaction, case-insensitive matching, and string-input path
- **`README.md`** — new row in options table, usage example with false-positive explanation, and a note on the pattern-level vs key-level trade-off

## Related Tickets and/or Pull Requests

Relates to #319

## Checklist

- [x] Tests added or updated
- [x] README and TSDoc updated if the public API changed
- [ ] Breaking changes called out (if any)
- [x] Roadmap item checked off if this PR completes one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ignorePatterns` option to exclude specific patterns from data sanitization, preventing unintended masking when default or custom patterns partially match legitimate field names.

* **Documentation**
  * Updated README with `ignorePatterns` option description, usage examples, and guidance on interaction with other configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->