### PR TITLE
feat(data-sanitization)!: change parseJsonStrings default to true

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -221,19 +221,13 @@ Tests in `test/matchers.test.ts` and `test/replacers.test.ts` already document
 the current behavior; the comment in `replacers.test.ts` flags this as a v2
 decision point.
 
-### `parseJsonStrings: true` as the Default
+### `parseJsonStrings: true` as the Default — completed in #322
 
-The current default is `parseJsonStrings: false`, meaning string inputs go
-through the regex path. A future major version could flip the default so that
-valid JSON strings are always sanitized via `objectReplacer` (full type
-coverage, including numeric and boolean sensitive values) and fall back to
-regex only for non-JSON text.
-
-This is a **behavior-breaking change** — any caller relying on the current
-regex-path output for JSON strings (e.g. value format, whitespace
-preservation) would be affected. A migration path would need to be documented.
-See the comment in `test/replacers.test.ts` line 543 for the test note
-tracking this.
+Valid JSON object and array strings are now always sanitized via `objectReplacer`
+by default (full type coverage, including numeric and boolean sensitive values),
+with automatic fallback to text-based matching for non-JSON strings. Callers
+relying on the regex-path output for JSON strings (e.g. value format, whitespace
+preservation) must opt out with `parseJsonStrings: false`.
 
 ### Non-Plain Object Type Support
 

--- a/docs/plans/019-parse-json-strings-default.md
+++ b/docs/plans/019-parse-json-strings-default.md
@@ -1,0 +1,182 @@
+# Plan 019 — Change `parseJsonStrings` Default to `true`
+
+## Overview
+
+Flip the `parseJsonStrings` default from `false` to `true`. This is a breaking
+change (v2) committed with `feat!:` to signal a semver major bump.
+
+The regex path only matches string-quoted values; non-string JSON values such
+as booleans, `null`, arrays, and nested objects are invisible to it. Defaulting
+to `true` routes valid JSON object/array strings through `objectReplacer`, which
+handles all value types correctly and is 3–4× faster for typical JSON payloads.
+
+Non-JSON strings continue to fall back to the regex path automatically.
+
+## Branch
+
+`feat/019-parse-json-strings-default`
+
+## Files to Change
+
+- `packages/data-sanitization/src/replacers.ts`
+- `packages/data-sanitization/src/types.ts`
+- `packages/data-sanitization/test/replacers.test.ts`
+- `packages/data-sanitization/README.md`
+- `docs/ROADMAP.md`
+
+---
+
+## Tasks
+
+### Task 1 — Update `replacers.ts` default
+
+**File:** `packages/data-sanitization/src/replacers.ts`
+
+Change the default destructuring value:
+
+```diff
+-  parseJsonStrings = false,
++  parseJsonStrings = true,
+```
+
+No other logic changes are needed — the branch that checks `if (parseJsonStrings)` already handles the object/array parse-and-sanitize path, and the regex fallback path continues to handle non-JSON strings.
+
+**Verification:** `yarn workspace data-sanitization test test/replacers.test.ts`
+(will fail before test updates — that is expected)
+
+---
+
+### Task 2 — Update `types.ts` JSDoc
+
+**File:** `packages/data-sanitization/src/types.ts`
+
+In the `parseJsonStrings` property doc block, change the default note:
+
+```diff
+- * Default: false
++ * Default: true
+```
+
+---
+
+### Task 3 — Rework `test/replacers.test.ts` paired tests
+
+**File:** `packages/data-sanitization/test/replacers.test.ts`
+
+The "with edge case string inputs" describe block (currently lines ~539–716)
+contains 5 pairs of tests. Each pair documents:
+
+1. Default path: value left unchanged (regex path, `parseJsonStrings: false`)
+2. Explicit path: value masked (`parseJsonStrings: true`)
+
+With the new default, the pairs swap roles. Update each pair as follows:
+
+**Pattern for each pair:**
+
+- First test (formerly "default unchanged"): add explicit `parseJsonStrings: false`
+  and update the `it()` title to describe the regex-path behavior.
+  Example: `'should leave a boolean sensitive field value unchanged'`
+  → `'should leave a boolean sensitive field value unchanged when JSON string parsing is disabled'`
+
+- Second test (formerly "parseJsonStrings: true"): remove the explicit
+  `parseJsonStrings: true` option (now tests the new default) and update the
+  `it()` title to drop "when JSON string parsing is enabled".
+  Example: `'should mask a sensitive field whose value is a boolean when JSON string parsing is enabled'`
+  → `'should mask a sensitive field whose value is a boolean'`
+
+**Pairs to update (5 total):**
+
+1. boolean sensitive field value
+2. null sensitive field value
+3. array sensitive field value
+4. nested object sensitive field value
+5. empty string sensitive field value
+
+**Empty string test (line ~649):**
+
+The first test only asserts valid JSON + non-sensitive field preserved. With the
+new default, `password: ""` → masked via objectReplacer. The first test still
+passes (valid JSON, username preserved). Strengthen it to also assert
+`result.password === DEFAULT_PATTERN_MASK` when adding `parseJsonStrings: false`
+— wait, with `parseJsonStrings: false` the regex path DOES handle empty strings
+(it matches `"password":""`). So:
+
+- With `parseJsonStrings: false`: regex path masks empty string → `DEFAULT_PATTERN_MASK`
+- With `parseJsonStrings: true` (new default): object path masks empty string → `DEFAULT_PATTERN_MASK`
+
+So the first test with explicit `parseJsonStrings: false` can assert masking
+too. The second test (default) can assert masking without the explicit option.
+
+**Escaped quote test (line ~675):**
+
+Both paths produce valid JSON with non-sensitive fields preserved. The second
+test (default path) can drop `parseJsonStrings: true` and assert full masking.
+
+**Update the comment:**
+
+Replace the comment block at the start of the describe (lines 540–544) with:
+
+```
+// The regex path only matches string-quoted values. For each non-string value
+// type below there are two paired tests: the parseJsonStrings: false path
+// documents that the value is left unchanged on the regex path, and the default
+// path documents that masking works correctly via objectReplacer.
+```
+
+**Verification:** `yarn workspace data-sanitization test test/replacers.test.ts`
+
+---
+
+### Task 4 — Update README
+
+**File:** `packages/data-sanitization/README.md`
+
+1. In the options table, update the `parseJsonStrings` row default column:
+   - `false` → `true`
+   - Also update the description column to remove the "setting it to true" framing
+     and describe it as the default behavior
+
+2. In the "Parse JSON strings" subsection (currently says "Setting
+   `parseJsonStrings: true`..."), update to describe the feature as the default.
+   Add a note that callers can opt out with `parseJsonStrings: false` when
+   formatting fidelity (original whitespace/indentation) is required.
+
+**Verification:** `yarn workspace data-sanitization lint`
+
+---
+
+### Task 5 — Update ROADMAP
+
+**File:** `docs/ROADMAP.md`
+
+Mark the "`parseJsonStrings: true` as the Default" v2 candidate as completed,
+linking this PR.
+
+---
+
+### Task 6 — Run full test suite and verify coverage
+
+```bash
+yarn workspace data-sanitization test
+yarn workspace data-sanitization test --coverage
+```
+
+All tests must pass and coverage must be 100%.
+
+---
+
+### Task 7 — Commit
+
+```
+feat!: change parseJsonStrings default to true
+
+Route valid JSON object/array strings through objectReplacer by default.
+This handles non-string sensitive values (boolean, null, array, nested
+object) that the regex path cannot mask. Non-JSON strings fall back to
+the regex path automatically.
+
+Callers relying on the regex-path output for JSON strings (value format,
+whitespace preservation) must now opt out with parseJsonStrings: false.
+```
+
+Commit both the plan file and all implementation changes in one commit.

--- a/packages/data-sanitization-log-providers/src/pino-hook.ts
+++ b/packages/data-sanitization-log-providers/src/pino-hook.ts
@@ -35,6 +35,7 @@ function createSanitizeLogLine(
   } = options;
 
   return function sanitizeLogLine(s: string): string {
+    const endsWithNewline = s.endsWith('\n');
     let result: ReturnType<typeof sanitizeLine>;
     try {
       result = sanitizeLine(s, sanitizeOptions, allowedFields);
@@ -46,10 +47,11 @@ function createSanitizeLogLine(
     }
 
     const { sanitized, warning } = result;
-    if (warning) {
-      return warning + '\n' + sanitized;
+    const output = warning ? warning + '\n' + sanitized : sanitized;
+    if (endsWithNewline && !output.endsWith('\n')) {
+      return output + '\n';
     }
-    return sanitized;
+    return output;
   };
 }
 

--- a/packages/data-sanitization-log-providers/test/pino-hook.test.ts
+++ b/packages/data-sanitization-log-providers/test/pino-hook.test.ts
@@ -21,6 +21,19 @@ describe('pino-hook', () => {
       expect(result).toBe(clean);
     });
 
+    it('should not append a trailing newline when the sanitized output already ends with one', () => {
+      // Arrange
+      // parseJsonStrings: false forces the regex path, which preserves the
+      // trailing \n in the output; the hook must not double-append it.
+      const hook = createSanitizeLogLine({ parseJsonStrings: false });
+
+      // Act
+      const result = hook(clean);
+
+      // Assert
+      expect(result).toBe(clean);
+    });
+
     it('should sanitize a sensitive field and return a masked line', () => {
       // Arrange
       const hook = createSanitizeLogLine();

--- a/packages/data-sanitization/README.md
+++ b/packages/data-sanitization/README.md
@@ -206,33 +206,34 @@ sanitizeData('password=secret&username=mark');
 
 ### Parse JSON strings
 
-By default, string inputs are sanitized using text-based pattern matching.
-This works for most cases, but it cannot detect numeric-valued sensitive fields:
+By default, valid JSON object and array strings are parsed first and sanitized
+the same way an object would be. This correctly handles all value types,
+including numeric-valued sensitive fields:
 
 ```typescript
 sanitizeData('{"password":12345,"username":"mark"}');
-// => '{"password":12345,"username":"mark"}' (numeric value not masked)
-```
-
-Setting `parseJsonStrings: true` parses the JSON first and sanitizes it the
-same way an object would be, which handles numeric values correctly:
-
-```typescript
-sanitizeData('{"password":12345,"username":"mark"}', {
-  parseJsonStrings: true,
-});
 // => '{"password":9999999999,"username":"mark"}'
 ```
 
-> [!TIP]
-> `parseJsonStrings: true` is also 3–4× faster for JSON string inputs than the
-> default text-based approach. The tradeoff is that output is re-serialized with
-> `JSON.stringify`, which does not preserve original whitespace or formatting.
+Non-JSON strings fall back to text-based pattern matching automatically.
+
+> [!NOTE]
+> Output is re-serialized with `JSON.stringify`, which does not preserve
+> original whitespace or formatting. Set `parseJsonStrings: false` to use
+> text-based matching instead when formatting fidelity is required or when
+> the input is never JSON:
+>
+> ```typescript
+> sanitizeData('{"password":12345,"username":"mark"}', {
+>   parseJsonStrings: false,
+> });
+> // => '{"password":12345,"username":"mark"}' (numeric value not masked on regex path)
+> ```
 
 If the string cannot be parsed as JSON, `sanitizeData` silently falls back to
-text-based pattern matching. Numeric-valued sensitive fields will not be masked
-in that case. If you need strict behavior (fail or redact on parse failure),
-[open an issue](https://github.com/ioncache/data-sanitization/issues/306) — this is tracked for a future release.
+text-based pattern matching. If you need strict behavior (fail or redact on
+parse failure), [open an issue](https://github.com/ioncache/data-sanitization/issues/306)
+— this is tracked for a future release.
 
 ### Remove fields instead of masking
 
@@ -335,8 +336,8 @@ sanitizeData({ tags }, { sanitizeCollections: true });
 | `numericMask`         | `number`                    | `9999999999` | Number used to replace matched number field values                                                                                                                                 |
 | `removeMatches`       | `boolean`                   | `false`      | Remove matched fields entirely instead of masking                                                                                                                                  |
 | `sanitizeCollections` | `boolean`                   | `false`      | Sanitize `Map` and `Set` instances by traversing their entries and returning a new sanitized copy. When false, these pass through unchanged like other non-plain object instances. |
-| `scanStringValues`    | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns. Applies to object input and to string input when `parseJsonStrings` is enabled; has no effect on raw string input. |
-| `parseJsonStrings`    | `boolean`                   | `false`      | Parse valid JSON string inputs as structured data and sanitize by field name. Re-serializes with `JSON.stringify`, discarding original whitespace.                                 |
+| `scanStringValues`    | `boolean`                   | `true`       | Scan string values on non-sensitive keys for embedded patterns. Applies to object input and to string input parsed via `parseJsonStrings`; has no effect on raw string input.      |
+| `parseJsonStrings`    | `boolean`                   | `true`       | Parse valid JSON string inputs as structured data and sanitize by field name. Re-serializes with `JSON.stringify`, discarding whitespace. Set to `false` to use the regex path.    |
 | `customPatterns`      | `PatternEntry[]`            | `[]`         | Additional field name patterns to match. Each entry is a pattern string (substring match) or `{ match: string; strict?: boolean }` for an exact match.                             |
 | `customMatchers`      | `DataSanitizationMatcher[]` | `[]`         | Additional regex matchers for custom string formats                                                                                                                                |
 | `useDefaultPatterns`  | `boolean`                   | `true`       | Set to `false` to use only your custom patterns, ignoring the built-in defaults.                                                                                                   |
@@ -590,8 +591,9 @@ fields; a single 10KB non-sensitive string value incurs ~68% overhead.
 > Set `scanStringValues: false` when you control your data structure and know
 > sensitive values only appear on sensitive-named keys. This recovers full pre-scanning throughput.
 >
-> Set `parseJsonStrings: true` when your string inputs are JSON. It is 3–4× faster
-> than the default regex path and correctly masks numeric-valued sensitive fields.
+> JSON string inputs are parsed and sanitized via `objectReplacer` by default,
+> which is 3–4× faster than the regex path and correctly masks numeric-valued
+> sensitive fields. Set `parseJsonStrings: false` to use the regex path instead.
 
 On first call with a given set of options, `sanitizeData` compiles its regex
 set and caches the result by option fingerprint. Subsequent calls with the same

--- a/packages/data-sanitization/src/replacers.ts
+++ b/packages/data-sanitization/src/replacers.ts
@@ -181,7 +181,7 @@ const stringReplacer: DataSanitizationReplacer = (data, options = {}) => {
     customMatchers,
     customPatterns,
     ignorePatterns,
-    parseJsonStrings = false,
+    parseJsonStrings = true,
     patternMask,
     removeMatches = false,
     useDefaultMatchers = true,

--- a/packages/data-sanitization/src/types.ts
+++ b/packages/data-sanitization/src/types.ts
@@ -60,10 +60,10 @@ interface DataSanitizationReplacerOptions {
    * or parses to a primitive. Has no effect on non-string input.
    *
    * Note: JSON.stringify does not preserve original whitespace or
-   * indentation. Enable this option only when formatting fidelity is
-   * not required.
+   * indentation. Set to `false` when formatting fidelity is required
+   * or when the input is never JSON.
    *
-   * Default: false
+   * Default: true
    */
   parseJsonStrings?: boolean;
   /**

--- a/packages/data-sanitization/test/replacers.test.ts
+++ b/packages/data-sanitization/test/replacers.test.ts
@@ -329,8 +329,9 @@ describe('DataSanitizationReplacers', () => {
         // Arrange
         const testData = '{"password":"foo","username":"bar"}';
 
-        // Act
+        // Act — regex path: disabling matchers means no patterns are applied
         const result = stringReplacer(testData, {
+          parseJsonStrings: false,
           useDefaultMatchers: false,
         }) as string;
 
@@ -360,13 +361,15 @@ describe('DataSanitizationReplacers', () => {
       });
     });
 
-    describe('when JSON string parsing is enabled', () => {
+    describe('with JSON string inputs', () => {
       it('should not mask numeric sensitive field values when JSON string parsing is disabled', () => {
         // Arrange
         const testData = '{"password":12345,"username":"mark"}';
 
         // Act
-        const result = JSON.parse(stringReplacer(testData) as string);
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: false }) as string,
+        );
 
         // Assert
         expect(result.password).toBe(12345);
@@ -538,89 +541,102 @@ describe('DataSanitizationReplacers', () => {
 
     describe('with edge case string inputs', () => {
       // The regex path only matches string-quoted values. For each non-string value
-      // type below there are two paired tests: the default path documents that the
-      // value is left unchanged, and the parseJsonStrings: true path documents that
-      // masking works correctly via objectReplacer. When parseJsonStrings defaults
-      // to true in v2 the default-path behaviour will change accordingly.
-      it('should leave a boolean sensitive field value unchanged', () => {
+      // type below there are two paired tests: the parseJsonStrings: false path
+      // documents that the value is left unchanged on the regex path, and the default
+      // path documents that masking works correctly via objectReplacer.
+      it('should leave a boolean sensitive field value unchanged when JSON string parsing is disabled', () => {
         // Arrange
         const testData = '{"password":true,"username":"mark"}';
 
         // Act
-        const result = JSON.parse(stringReplacer(testData) as string);
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: false }) as string,
+        );
 
         // Assert
         expect(result.password).toBe(true);
         expect(result.username).toBe('mark');
       });
 
-      it('should mask a sensitive field whose value is a boolean when JSON string parsing is enabled', () => {
+      it('should mask a sensitive field whose value is a boolean', () => {
         // Arrange
         const testData = '{"password":true,"username":"mark"}';
 
         // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        );
+        const result = JSON.parse(stringReplacer(testData) as string);
 
         // Assert
         expect(result.password).toBe(DEFAULT_PATTERN_MASK);
         expect(result.username).toBe('mark');
       });
 
-      it('should leave a null sensitive field value unchanged', () => {
+      it('should leave a null sensitive field value unchanged when JSON string parsing is disabled', () => {
         // Arrange
         const testData = '{"password":null,"username":"mark"}';
 
         // Act
-        const result = JSON.parse(stringReplacer(testData) as string);
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: false }) as string,
+        );
 
         // Assert
         expect(result.password).toBeNull();
         expect(result.username).toBe('mark');
       });
 
-      it('should mask a sensitive field whose value is null when JSON string parsing is enabled', () => {
+      it('should mask a sensitive field whose value is null', () => {
         // Arrange
         const testData = '{"password":null,"username":"mark"}';
 
         // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        );
+        const result = JSON.parse(stringReplacer(testData) as string);
 
         // Assert
         expect(result.password).toBe(DEFAULT_PATTERN_MASK);
         expect(result.username).toBe('mark');
       });
 
-      it('should leave an array sensitive field value unchanged', () => {
+      it('should leave an array sensitive field value unchanged when JSON string parsing is disabled', () => {
         // Arrange
         const testData = '{"token":["a","b","c"],"username":"mark"}';
 
         // Act
-        const result = JSON.parse(stringReplacer(testData) as string);
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: false }) as string,
+        );
 
         // Assert
         expect(result.token).toEqual(['a', 'b', 'c']);
         expect(result.username).toBe('mark');
       });
 
-      it('should mask a sensitive field whose value is an array when JSON string parsing is enabled', () => {
+      it('should mask a sensitive field whose value is an array', () => {
         // Arrange
         const testData = '{"token":["a","b","c"],"username":"mark"}';
 
         // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        );
+        const result = JSON.parse(stringReplacer(testData) as string);
 
         // Assert
         expect(result.token).toBe(DEFAULT_PATTERN_MASK);
         expect(result.username).toBe('mark');
       });
 
-      it('should leave a nested object sensitive field value unchanged', () => {
+      it('should leave a nested object sensitive field value unchanged when JSON string parsing is disabled', () => {
+        // Arrange
+        const testData = '{"token":{"nested":"value"},"username":"mark"}';
+
+        // Act
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: false }) as string,
+        );
+
+        // Assert
+        expect(result.token).toEqual({ nested: 'value' });
+        expect(result.username).toBe('mark');
+      });
+
+      it('should mask a sensitive field whose value is a nested object', () => {
         // Arrange
         const testData = '{"token":{"nested":"value"},"username":"mark"}';
 
@@ -628,32 +644,20 @@ describe('DataSanitizationReplacers', () => {
         const result = JSON.parse(stringReplacer(testData) as string);
 
         // Assert
-        expect(result.token).toEqual({ nested: 'value' });
-        expect(result.username).toBe('mark');
-      });
-
-      it('should mask a sensitive field whose value is a nested object when JSON string parsing is enabled', () => {
-        // Arrange
-        const testData = '{"token":{"nested":"value"},"username":"mark"}';
-
-        // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        );
-
-        // Assert
         expect(result.token).toBe(DEFAULT_PATTERN_MASK);
         expect(result.username).toBe('mark');
       });
 
-      it('should produce valid JSON when a sensitive field value is an empty string', () => {
+      it('should produce valid JSON when a sensitive field value is an empty string and JSON string parsing is disabled', () => {
         // Arrange
         const testData = '{"password":"","username":"mark"}';
 
         // Act
-        const result = stringReplacer(testData) as string;
+        const result = stringReplacer(testData, {
+          parseJsonStrings: false,
+        }) as string;
 
-        // Assert — output must remain parseable and preserve non-sensitive fields
+        // Assert — regex path leaves empty string values unmasked but output remains valid JSON
         expect(() => JSON.parse(result)).not.toThrow();
         expect(JSON.parse(result).username).toBe('mark');
       });
@@ -663,16 +667,14 @@ describe('DataSanitizationReplacers', () => {
         const testData = '{"password":"","username":"mark"}';
 
         // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        );
+        const result = JSON.parse(stringReplacer(testData) as string);
 
         // Assert
         expect(result.password).toBe(DEFAULT_PATTERN_MASK);
         expect(result.username).toBe('mark');
       });
 
-      it('should produce valid JSON when a sensitive field value contains an escaped quote', () => {
+      it('should produce valid JSON when a sensitive field value contains an escaped quote and JSON string parsing is disabled', () => {
         // Arrange — value is: sec"ret  (JSON.stringify encodes the inner quote as \")
         const testData = JSON.stringify({
           password: 'sec"ret',
@@ -680,7 +682,9 @@ describe('DataSanitizationReplacers', () => {
         });
 
         // Act
-        const result = stringReplacer(testData) as string;
+        const result = stringReplacer(testData, {
+          parseJsonStrings: false,
+        }) as string;
 
         // Assert — output must remain valid JSON with non-sensitive fields preserved
         expect(() => JSON.parse(result)).not.toThrow();
@@ -695,9 +699,7 @@ describe('DataSanitizationReplacers', () => {
         });
 
         // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        );
+        const result = JSON.parse(stringReplacer(testData) as string);
 
         // Assert
         expect(result.password).toBe(DEFAULT_PATTERN_MASK);
@@ -708,11 +710,8 @@ describe('DataSanitizationReplacers', () => {
         // Arrange
         const testData = '{"password":';
 
-        // Act + Assert
+        // Act + Assert — JSON.parse fails; falls back to regex path without throwing
         expect(() => stringReplacer(testData)).not.toThrow();
-        expect(() =>
-          stringReplacer(testData, { parseJsonStrings: true }),
-        ).not.toThrow();
       });
 
       it('should not throw on a JSON fragment with no opening brace', () => {
@@ -782,7 +781,7 @@ describe('DataSanitizationReplacers', () => {
         const inner = JSON.stringify({ password: 'secret', user: 'mark' });
         const outer = JSON.stringify({ log: inner, username: 'mark' });
 
-        // Act — escapedJsonMatcher targets \" delimiters in the serialised outer string
+        // Act — outer parsed via objectReplacer; 'log' string scanned and re-parsed as JSON
         const result = JSON.parse(stringReplacer(outer) as string);
 
         // Assert
@@ -790,15 +789,14 @@ describe('DataSanitizationReplacers', () => {
         expect(result.username).toBe('mark');
       });
 
-      it('should mask inner sensitive fields in double-encoded JSON when JSON string parsing is enabled', () => {
+      it('should mask sensitive fields in the inner JSON of a double-encoded string when JSON string parsing is disabled', () => {
         // Arrange
         const inner = JSON.stringify({ password: 'secret', user: 'mark' });
         const outer = JSON.stringify({ log: inner, username: 'mark' });
 
-        // Act — parseJsonStrings parses the outer object; the 'log' string value
-        // is sanitized through the regex path which catches the escaped JSON
+        // Act — regex path: escapedJsonMatcher targets \" delimiters in the serialised outer string
         const result = JSON.parse(
-          stringReplacer(outer, { parseJsonStrings: true }) as string,
+          stringReplacer(outer, { parseJsonStrings: false }) as string,
         );
 
         // Assert
@@ -929,12 +927,9 @@ describe('DataSanitizationReplacers', () => {
 
         // Act + Assert
         expect(() => stringReplacer(level3)).not.toThrow();
-        expect(() =>
-          stringReplacer(level3, { parseJsonStrings: true }),
-        ).not.toThrow();
       });
 
-      it('should mask string values and leave non-string sensitive field values unchanged', () => {
+      it('should mask string values and leave non-string sensitive field values unchanged when JSON string parsing is disabled', () => {
         // Arrange — mixed-type array: same key with different value types across objects
         const testData = JSON.stringify([
           { password: 'string-secret' },
@@ -942,11 +937,10 @@ describe('DataSanitizationReplacers', () => {
           { username: 'mark' },
         ]);
 
-        // Act
-        const result = JSON.parse(stringReplacer(testData) as string) as Record<
-          string,
-          unknown
-        >[];
+        // Act — regex path: can only match string-quoted values
+        const result = JSON.parse(
+          stringReplacer(testData, { parseJsonStrings: false }) as string,
+        ) as Record<string, unknown>[];
 
         // Assert — string value is masked; numeric value is left unchanged on the regex path
         expect(result[0]?.password).toBe(DEFAULT_PATTERN_MASK);
@@ -954,7 +948,7 @@ describe('DataSanitizationReplacers', () => {
         expect(result[2]?.username).toBe('mark');
       });
 
-      it('should mask sensitive field values regardless of their type when JSON string parsing is enabled', () => {
+      it('should mask sensitive field values regardless of their type', () => {
         // Arrange
         const testData = JSON.stringify([
           { password: 'string-secret' },
@@ -962,9 +956,10 @@ describe('DataSanitizationReplacers', () => {
         ]);
 
         // Act
-        const result = JSON.parse(
-          stringReplacer(testData, { parseJsonStrings: true }) as string,
-        ) as Record<string, unknown>[];
+        const result = JSON.parse(stringReplacer(testData) as string) as Record<
+          string,
+          unknown
+        >[];
 
         // Assert
         expect(result[0]?.password).toBe(DEFAULT_PATTERN_MASK);

--- a/packages/data-sanitization/test/replacers.test.ts
+++ b/packages/data-sanitization/test/replacers.test.ts
@@ -686,9 +686,10 @@ describe('DataSanitizationReplacers', () => {
           parseJsonStrings: false,
         }) as string;
 
-        // Assert — output must remain valid JSON with non-sensitive fields preserved
-        expect(() => JSON.parse(result)).not.toThrow();
-        expect(JSON.parse(result).username).toBe('mark');
+        // Assert
+        const parsed = JSON.parse(result) as Record<string, unknown>;
+        expect(parsed.password).toBe(DEFAULT_PATTERN_MASK);
+        expect(parsed.username).toBe('mark');
       });
 
       it('should mask a sensitive field whose value contains an embedded quote character', () => {


### PR DESCRIPTION
# Overview

Change the `parseJsonStrings` default from `false` to `true` so that valid JSON object and array strings are routed through `objectReplacer` by default. This is a v2 breaking change.

## Details

- **`src/replacers.ts`**: `parseJsonStrings = false` → `parseJsonStrings = true` in `stringReplacer`
- **`src/types.ts`**: Updated JSDoc to reflect new default and reframe the opt-out note
- **`test/replacers.test.ts`**: Reworked the five paired "regex path vs object path" tests — the `parseJsonStrings: false` tests now carry explicit options; the default tests drop the redundant `parseJsonStrings: true`; describe block renamed from "when JSON string parsing is enabled" to "with JSON string inputs"
- **`README.md`**: Updated options table default, the "Parse JSON strings" subsection, and the performance tip to reflect the new default
- **`docs/ROADMAP.md`**: Marked the `parseJsonStrings: true` as default v2 candidate complete
- **`docs/plans/019-parse-json-strings-default.md`**: Plan committed alongside implementation

**Why this is better as the default:**
- Handles boolean, null, array, and nested-object sensitive values that the regex path cannot mask
- 3–4× faster for typical JSON string workloads
- Non-JSON strings fall back to the regex path automatically — no behaviour change for non-JSON callers

**Migration:** callers relying on the regex-path output format (whitespace preservation, exact value formatting) must opt out with `parseJsonStrings: false`.

## Related Tickets and/or Pull Requests

Relates to #306 (strict mode follow-up remains open)

## Checklist

- [x] Tests added or updated
- [x] README and TSDoc updated if the public API changed
- [x] Breaking changes called out (if any)
- [x] Roadmap item checked off if this PR completes one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * parseJsonStrings now defaults to true — JSON object/array strings are parsed and sanitized by default. Set parseJsonStrings: false to preserve prior regex/text masking and exact string formatting.

* **Documentation**
  * Roadmap, plan, and package README updated to describe the new default, behavior, examples, and performance guidance.

* **Bug Fixes**
  * Sanitized log output preserves/normalizes trailing newline behavior.

* **Tests**
  * Test suites updated to cover default vs. opt-out behaviors and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ioncache/data-sanitization/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->